### PR TITLE
feat: switch from Date to Temporal

### DIFF
--- a/components/ArticlePreview/ArticlePreview.tsx
+++ b/components/ArticlePreview/ArticlePreview.tsx
@@ -1,5 +1,6 @@
 import type { NextPage } from "next";
 import Link from "next/link";
+import { Temporal } from '@js-temporal/polyfill';
 
 type Props = {
   title: string;
@@ -22,8 +23,8 @@ const ArticlePreview: NextPage<Props> = ({
   date,
   readTime,
 }) => {
-  const dateTime = new Date(date).toTimeString();
-  const readableDate = new Date(date).toLocaleDateString(undefined, {
+  const dateTime = Temporal.PlainDate.from(date);
+  const readableDate = dateTime.toLocaleString(['en-IE'], {
     year: "numeric",
     month: "long",
     day: "numeric",
@@ -32,7 +33,7 @@ const ArticlePreview: NextPage<Props> = ({
   return (
     <article className="p-4 border-2 border-white my-4 shadow-lg shadow-pink-500/50">
       <div className="flex space-x-1 text-sm text-gray-500 mb-2">
-        <time dateTime={dateTime}>{readableDate}</time>
+        <time dateTime={dateTime.toString()}>{readableDate}</time>
         {readTime && (
           <>
             <span aria-hidden="true">&middot;</span>

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -1,6 +1,7 @@
 import type { NextPage } from "next";
 import Link from "next/link";
 import { SVGProps } from "react";
+import { Temporal } from "@js-temporal/polyfill";
 
 import {
   footerNav,
@@ -116,7 +117,7 @@ const Footer: NextPage = () => {
           ))}
         </div>
         <p className="mt-8 text-center text-base text-gray-500">
-          &copy; {new Date().getFullYear()} Codú Software Solutions, Ltd.
+          &copy; {Temporal.Now.plainDateISO().year} Codú Software Solutions, Ltd.
         </p>
       </div>
     </footer>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@headlessui/react": "^1.6.1",
         "@heroicons/react": "^1.0.6",
+        "@js-temporal/polyfill": "^0.4.2",
         "clsx": "^1.2.1",
         "fathom-client": "^3.5.0",
         "next": "12.2.0",
@@ -1919,6 +1920,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.4.2.tgz",
+      "integrity": "sha512-c85vRxyqnJaXKyf4tvYij8jwiVIZhNLYDI9C4LLuOwVEHf4HUqGg07BBn70Le71W193QT/vmKg3jPUyQxJRHKQ==",
+      "dependencies": {
+        "jsbi": "^4.1.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@next/env": {
@@ -4831,6 +4844,11 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbi": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.0.tgz",
+      "integrity": "sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g=="
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
@@ -7856,6 +7874,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@js-temporal/polyfill": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.4.2.tgz",
+      "integrity": "sha512-c85vRxyqnJaXKyf4tvYij8jwiVIZhNLYDI9C4LLuOwVEHf4HUqGg07BBn70Le71W193QT/vmKg3jPUyQxJRHKQ==",
+      "requires": {
+        "jsbi": "^4.1.0",
+        "tslib": "^2.3.1"
+      }
+    },
     "@next/env": {
       "version": "12.2.0",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-12.2.0.tgz",
@@ -9877,6 +9904,11 @@
       "requires": {
         "argparse": "^2.0.1"
       }
+    },
+    "jsbi": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.0.tgz",
+      "integrity": "sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g=="
     },
     "jsesc": {
       "version": "2.5.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@headlessui/react": "^1.6.1",
     "@heroicons/react": "^1.0.6",
+    "@js-temporal/polyfill": "^0.4.2",
     "clsx": "^1.2.1",
     "fathom-client": "^3.5.0",
     "next": "12.2.0",


### PR DESCRIPTION
https://tc39.es/proposal-temporal/docs/

ran into some cases where the server hydration would break because of a difference in locale between server and client. Proper fix is to restrict it to client side only, but for now I'll hardcode it to `en-IE`, and ditch the useless Date for the glorious if still in Stage 3 Temporal.