### PR TITLE
Fixes redirect on publish

### DIFF
--- a/pages/create/[[...postIdArr]].tsx
+++ b/pages/create/[[...postIdArr]].tsx
@@ -113,8 +113,8 @@ const Create: NextPage = () => {
       return publish(
         { id: postId, published: !published },
         {
-          onSuccess() {
-            data?.slug && router.push(`/articles/${data.slug}`);
+          onSuccess(response) {
+            response?.slug && router.push(`/articles/${response.slug}`);
           },
         }
       );


### PR DESCRIPTION
Occasionally redirect was taking the user to 404.

Now redirects based on response instead of the state. 