### PR TITLE
Show article tags below heading

### DIFF
--- a/pages/articles/[slug].tsx
+++ b/pages/articles/[slug].tsx
@@ -27,6 +27,20 @@ const ArticlePage: NextPage = ({
             <h2 className="pt-4 sm:my-5 text-3xl font-bold leading-tight">
               {post.title}
             </h2>
+
+            {post.tags.length > 0 && (
+              <section className="flex flex-wrap gap-2">
+                {post.tags.map((tag) => (
+                  <div
+                    key={tag.id}
+                    className="bg-pink-600 hover:bg-pink-700 text-white py-2 px-4 rounded-full text-xs"
+                  >
+                    {tag.title}
+                  </div>
+                ))}
+              </section>
+            )}
+
             <article className="prose prose-invert">
               <ReactMarkdown rehypePlugins={[rehypePrism]}>
                 {post.body}
@@ -48,6 +62,7 @@ export const getServerSideProps = async (
       slug: ctx.params?.slug,
     },
     select: {
+      id: true,
       title: true,
       body: true,
       user: {
@@ -58,6 +73,19 @@ export const getServerSideProps = async (
           username: true,
         },
       },
+      tags: true,
+    },
+  });
+
+  const tags = await prisma.tag.findMany({
+    where: {
+      id: {
+        in: post?.tags.map((tag) => tag.tagId),
+      },
+    },
+    select: {
+      id: true,
+      title: true,
     },
   });
 
@@ -73,7 +101,10 @@ export const getServerSideProps = async (
 
   return {
     props: {
-      post,
+      post: {
+        ...post,
+        tags,
+      },
     },
   };
 };

--- a/pages/articles/[slug].tsx
+++ b/pages/articles/[slug].tsx
@@ -33,7 +33,7 @@ const ArticlePage: NextPage = ({
                 {post.tags.map((tag) => (
                   <div
                     key={tag.id}
-                    className="bg-pink-600 hover:bg-pink-700 text-white py-2 px-4 rounded-full text-xs"
+                    className="bg-gradient-to-r from-orange-400 to-pink-600 hover:bg-pink-700 text-white py-2 px-4 rounded-full text-xs"
                   >
                     {tag.title}
                   </div>


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

I'm just a bit unsure about the colors, what do you think?

## Pull Request details:
- Fetch post tags
- Display tags below article's heading
- Resolves #62 

## Any Breaking changes:
- None

## Associated Screenshots:
![image](https://user-images.githubusercontent.com/18503860/195964738-e9051dd4-ed73-41a0-a781-9ea18995ecd8.png)
on hover:
![image](https://user-images.githubusercontent.com/18503860/195964774-70e24978-86dc-4e9f-b23b-c92254400bec.png)