### PR TITLE
Add break-words class to excerpt paragraph

### DIFF
--- a/components/ArticlePreview/ArticlePreview.tsx
+++ b/components/ArticlePreview/ArticlePreview.tsx
@@ -60,7 +60,9 @@ const ArticlePreview: NextPage<Props> = ({
         </header>
       </Link>
 
-      <p className="tracking-wide text-sm md:text-lg my-3">{excerpt}</p>
+      <p className="tracking-wide text-sm md:text-lg my-3 break-words">
+        {excerpt}
+      </p>
       <div className="sm:flex justify-between content-center">
         <div className="flex items-center">
           <Link href={`/articles/${slug}`}>


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

## Pull Request details:
- Add `break-words` class to excerpt's `p` tag
- Resolves #67 
- There's also an issue with eslint in the same file because we are using an `img` tag instead of next's `Image` component. Should we ignore this eslint rule for this file?

## Any Breaking changes:
- None

## Associated Screenshots:
![image](https://user-images.githubusercontent.com/18503860/195982065-38cbbf7d-9f83-47cc-b09c-706f4c8100b2.png)