### PR TITLE
Fixed padding issues with author description.

### DIFF
--- a/components/BioBar/BioBar.tsx
+++ b/components/BioBar/BioBar.tsx
@@ -15,8 +15,8 @@ const BioFooter = ({ author }: Props) => {
 
   const { name, image, bio, username } = author;
   return (
-    <div className="max-w-xl px-4 mx-auto  text-gray-700 dark:text-gray-300 mt-6">
-      <div className="flex mx-2 sm:mx-6 md:mx-auto px-4 border-t-2 pt-6 border-gray-300 dark:border-gray-800">
+    <div className="max-w-xl mx-auto text-gray-700 dark:text-gray-300 mt-6">
+      <div className="flex mx-2 sm:mx-6 md:mx-auto border-t-2 pt-6 border-gray-300 dark:border-gray-800">
         <div className="mr-4 flex-shrink-0 self-center">
           <Image
             className="rounded-full"


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)


## Pull Request details:
- The Padding attributes "px-4" have been removed from Biobar.tsx file to fix the alignment issues with the author information at the end of each article.

## Any Breaking changes:
- None
## Associated Screenshots:
    
Before Commit
![image](https://user-images.githubusercontent.com/103755444/198697919-546613a3-4036-44df-a5d5-34ae39218e80.png)
After Commit
![image](https://user-images.githubusercontent.com/103755444/198697959-0b63f745-0972-42d8-b8c2-3194c90156e6.png)

Closes #89 
