### PR TITLE
Fetches host URL from ServerSideProps

### DIFF
--- a/components/Meta/Meta.tsx
+++ b/components/Meta/Meta.tsx
@@ -45,7 +45,7 @@ const Meta: NextPage = () => {
         key="og:image"
       />
       <meta property="og:type" content="website" />
-      <meta property="og:url" content="https://niall.af" />
+      <meta property="og:url" content="https://codu.co" />
     </Head>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "codu",
       "version": "0.1.0",
       "dependencies": {
         "@headlessui/react": "^1.6.1",

--- a/pages/articles/[slug].tsx
+++ b/pages/articles/[slug].tsx
@@ -13,9 +13,9 @@ import rehypePrism from "rehype-prism";
 
 const ArticlePage: NextPage = ({
   post,
+  host,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   if (!post) return null;
-
   return (
     <>
       <Head>
@@ -28,13 +28,10 @@ const ArticlePage: NextPage = ({
         />
         <meta key="description" property="description" content={post.excerpt} />
         <meta property="og:type" content="article" />
-        <meta
-          property="og:url"
-          content={`https://codu.co/articles/${post.slug}`}
-        />
+        <meta property="og:url" content={`${host}/articles/${post.slug}`} />
         <meta
           property="og:image"
-          content={`${process.env.BASE_URL || `http://localhost:3000`}/api/og?title=${post.title}`}
+          content={`${host}/api/og?title=${post.title}`}
         />
       </Head>
       <Layout>
@@ -117,8 +114,11 @@ export const getServerSideProps = async (
     };
   }
 
+  const host = ctx.req.headers.host || "";
+
   return {
     props: {
+      host,
       post: {
         ...post,
         tags,


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

## Pull Request details:
Change to grabbing the host URL from getServerSideProps so that the `og:url` will work in preview environments too. 
Also fixes a typo that had a copy-paste from niall.af

## Any Breaking changes:
None

## Associated Screenshots:
None