### PR TITLE
Add lang attribute to html element using i18n setting in next.config.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -19,4 +19,8 @@ module.exports = withBundleAnalyzer({
       "avatars.githubusercontent.com",
     ],
   },
+  i18n: {
+    locales: ["en"],
+    defaultLocale: "en",
+  },
 });


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

## Pull Request details:
- Adds an i18n setting in next.config.js to add `lang="en"` in `<html>` element.

## Any Breaking changes:
- None

## Associated Screenshots:
- None

Closes [#103](https://github.com/codu-code/codu/issues/103)