### PR TITLE
Fix unwanted elements spacing in the post preview

### DIFF
--- a/pages/create/[[...postIdArr]].tsx
+++ b/pages/create/[[...postIdArr]].tsx
@@ -408,10 +408,7 @@ const Create: NextPage = () => {
                           <h2 className="pt-4 sm:my-5 text-3xl font-bold leading-tight">
                             {title}
                           </h2>
-                          <article
-                            className="prose whitespace-pre-wrap"
-                            style={{ whiteSpace: "pre-wrap" }}
-                          >
+                          <article className="prose">
                             <ReactMarkdown rehypePlugins={[rehypePrism]}>
                               {body}
                             </ReactMarkdown>


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

## Pull Request details:
- The `whitespace-pre-wrap` class and `white-space: pre-wrap` style have been removed from `pages/create/[[...postIdArr]].tsx` file to fix the unwanted spacing around HTML elements.

## Any Breaking changes:
- none

## Associated Screenshots:
    
### Post Editor
![Screenshot 2022-11-07 at 14 07 05](https://user-images.githubusercontent.com/13404272/200331600-2c489ca6-eaef-4e07-8aa8-7899f54d1006.png)

### Post Preview
![Screenshot 2022-11-07 at 14 07 18](https://user-images.githubusercontent.com/13404272/200331790-a83c01dd-8251-4e3a-9ead-b007e9067b2b.png)

Closes [#56](https://github.com/codu-code/codu/issues/56)