### PR TITLE
Support CodePen in article markdown

### DIFF
--- a/components/markdocNodes/CodePen/CodePen.tsx
+++ b/components/markdocNodes/CodePen/CodePen.tsx
@@ -1,35 +1,29 @@
-import { useEffect } from "react";
-
 interface Props {
-  user: string;
-  slugHash: string;
+  src: string;
   defaultTab?: string;
   height?: string;
 }
 
 export function CodePen({
-  user,
-  slugHash,
+  src,
   defaultTab = 'result',
   height = '300px',
 }: Props) {
-  useEffect(() => {
-    const script = document.createElement('script');
-    script.src = 'https://cpwebassets.codepen.io/assets/embed/ei.js';
-    script.async = true;
-    document.body.appendChild(script);
-  }, []);
+  const codePenSrc = new URL(src);
+  if (!codePenSrc.searchParams.get('default-tab')) {
+    codePenSrc.searchParams.set('default-tab', defaultTab);
+  }
 
   return (
-    <p
-      className="codepen"
-      data-default-tab={defaultTab}
-      data-user={user}
-      data-slug-hash={slugHash}
+    <iframe
+      height={height}
       style={{ width: '100%' }}
-      data-height={height}
-    >
-      See the <a href={`https://codepen.io/${user}/pen/${slugHash}`}>Pen</a> by <a href={`https://codepen.io/${user}`}>@{user}</a> on <a href="https://codepen.io">CodePen</a>.
-    </p>
-  )
+      scrolling="no"
+      src={codePenSrc.toString()}
+      frameBorder="no"
+      loading="lazy"
+      allowTransparency
+      allowFullScreen
+    />
+  );
 }

--- a/components/markdocNodes/CodePen/CodePen.tsx
+++ b/components/markdocNodes/CodePen/CodePen.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 export function CodePen({
   src,
-  defaultTab = 'result',
+  defaultTab = 'html,result',
   height = '300px',
 }: Props) {
   const codePenSrc = new URL(src);

--- a/components/markdocNodes/CodePen/CodePen.tsx
+++ b/components/markdocNodes/CodePen/CodePen.tsx
@@ -1,0 +1,25 @@
+interface Props {
+  user: string;
+  slugHash: string;
+  defaultTab?: string;
+}
+
+export function CodePen({ user, slugHash, defaultTab = 'result' }: Props) {
+  const codePenSrc = new URL(`https://codepen.io/${user}/embed/${slugHash}`);
+  codePenSrc.searchParams.set('default-tab', defaultTab);
+
+  return (
+    <iframe
+      height={400}
+      style={{ width: '100%' }}
+      scrolling="no"
+      src={codePenSrc.toString()}
+      frameBorder="no"
+      loading="lazy"
+      allowTransparency
+      allowFullScreen
+    >
+      See the Pen <a href={`https://codepen.io/${user}/pen/${slugHash}`}>Responsive app showcase</a> by <a href={`https://codepen.io/${user}`}>@{user}</a> on <a href="https://codepen.io">CodePen</a>.
+    </iframe>
+  )
+}

--- a/components/markdocNodes/CodePen/CodePen.tsx
+++ b/components/markdocNodes/CodePen/CodePen.tsx
@@ -29,7 +29,7 @@ export function CodePen({
       style={{ width: '100%' }}
       data-height={height}
     >
-      See the Pen <a href={`https://codepen.io/${user}/pen/${slugHash}`}>Responsive app showcase</a> by <a href={`https://codepen.io/${user}`}>@{user}</a> on <a href="https://codepen.io">CodePen</a>.
+      See the <a href={`https://codepen.io/${user}/pen/${slugHash}`}>Pen</a> by <a href={`https://codepen.io/${user}`}>@{user}</a> on <a href="https://codepen.io">CodePen</a>.
     </p>
   )
 }

--- a/components/markdocNodes/CodePen/CodePen.tsx
+++ b/components/markdocNodes/CodePen/CodePen.tsx
@@ -4,9 +4,15 @@ interface Props {
   user: string;
   slugHash: string;
   defaultTab?: string;
+  height?: string;
 }
 
-export function CodePen({ user, slugHash, defaultTab = 'result' }: Props) {
+export function CodePen({
+  user,
+  slugHash,
+  defaultTab = 'result',
+  height = '400px',
+}: Props) {
   useEffect(() => {
     const script = document.createElement('script');
     script.src = 'https://cpwebassets.codepen.io/assets/embed/ei.js';
@@ -21,7 +27,7 @@ export function CodePen({ user, slugHash, defaultTab = 'result' }: Props) {
       data-user={user}
       data-slug-hash={slugHash}
       style={{ width: '100%' }}
-      data-height={400}
+      data-height={height}
     >
       See the Pen <a href={`https://codepen.io/${user}/pen/${slugHash}`}>Responsive app showcase</a> by <a href={`https://codepen.io/${user}`}>@{user}</a> on <a href="https://codepen.io">CodePen</a>.
     </p>

--- a/components/markdocNodes/CodePen/CodePen.tsx
+++ b/components/markdocNodes/CodePen/CodePen.tsx
@@ -11,7 +11,7 @@ export function CodePen({
   user,
   slugHash,
   defaultTab = 'result',
-  height = '400px',
+  height = '300px',
 }: Props) {
   useEffect(() => {
     const script = document.createElement('script');

--- a/components/markdocNodes/CodePen/CodePen.tsx
+++ b/components/markdocNodes/CodePen/CodePen.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+
 interface Props {
   user: string;
   slugHash: string;
@@ -5,21 +7,23 @@ interface Props {
 }
 
 export function CodePen({ user, slugHash, defaultTab = 'result' }: Props) {
-  const codePenSrc = new URL(`https://codepen.io/${user}/embed/${slugHash}`);
-  codePenSrc.searchParams.set('default-tab', defaultTab);
+  useEffect(() => {
+    const script = document.createElement('script');
+    script.src = 'https://cpwebassets.codepen.io/assets/embed/ei.js';
+    script.async = true;
+    document.body.appendChild(script);
+  }, []);
 
   return (
-    <iframe
-      height={400}
+    <p
+      className="codepen"
+      data-default-tab={defaultTab}
+      data-user={user}
+      data-slug-hash={slugHash}
       style={{ width: '100%' }}
-      scrolling="no"
-      src={codePenSrc.toString()}
-      frameBorder="no"
-      loading="lazy"
-      allowTransparency
-      allowFullScreen
+      data-height={400}
     >
       See the Pen <a href={`https://codepen.io/${user}/pen/${slugHash}`}>Responsive app showcase</a> by <a href={`https://codepen.io/${user}`}>@{user}</a> on <a href="https://codepen.io">CodePen</a>.
-    </iframe>
+    </p>
   )
 }

--- a/components/markdocNodes/CodePen/CodePen.tsx
+++ b/components/markdocNodes/CodePen/CodePen.tsx
@@ -22,7 +22,6 @@ export function CodePen({
       src={codePenSrc.toString()}
       frameBorder="no"
       loading="lazy"
-      allowTransparency
       allowFullScreen
     />
   );

--- a/markdoc/components.ts
+++ b/markdoc/components.ts
@@ -1,9 +1,11 @@
 import Code from "../components/markdocNodes/Code/Code";
+import { CodePen } from "../components/markdocNodes/CodePen/CodePen";
 import { CodeSandbox } from "../components/markdocNodes/CodeSandbox/CodeSandbox";
 import { YouTube } from "../components/markdocNodes/Youtube/Youtube";
 
 export const markdocComponents = {
   Code,
+  CodePen,
   Youtube: YouTube,
   CodeSandbox: CodeSandbox,
 };

--- a/markdoc/tags/codepen.markdoc.ts
+++ b/markdoc/tags/codepen.markdoc.ts
@@ -1,0 +1,18 @@
+const codepen = {
+  render: "CodePen",
+  attributes: {
+    user: {
+      type: String,
+      required: true,
+    },
+    slugHash: {
+      type: String,
+      required: true,
+    },
+    defaultTab: {
+      type: String,
+    },
+  },
+};
+
+export default codepen;

--- a/markdoc/tags/codepen.markdoc.ts
+++ b/markdoc/tags/codepen.markdoc.ts
@@ -1,5 +1,5 @@
 const codepen = {
-  render: "CodePen",
+  render: 'CodePen',
   attributes: {
     user: {
       type: String,
@@ -10,6 +10,9 @@ const codepen = {
       required: true,
     },
     defaultTab: {
+      type: String,
+    },
+    height: {
       type: String,
     },
   },

--- a/markdoc/tags/codepen.markdoc.ts
+++ b/markdoc/tags/codepen.markdoc.ts
@@ -1,11 +1,7 @@
 const codepen = {
   render: 'CodePen',
   attributes: {
-    user: {
-      type: String,
-      required: true,
-    },
-    slugHash: {
+    src: {
       type: String,
       required: true,
     },

--- a/markdoc/tags/index.ts
+++ b/markdoc/tags/index.ts
@@ -1,4 +1,5 @@
 module.exports['markdoc-example'] = markdocExample;
+export { default as codepen } from './codepen.markdoc';
 export { default as youtube } from './youtube.markdoc';
 export { default as codesandbox } from './codesandbox.markdoc';
 import markdocExample from './markdoc-example.markdoc';


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

## Pull Request details:
Resolve #154 

CodePen can now be embedded inside article markdown. The syntax looks like this:

```
{% codepen user="nguyen_thanhson" slugHash="JxWJoN" height="800px" /%}
```

`user` and `slugHash` are required attributes. `height` is an optional attribute, its default value is `300px` (the default value of a normal CodePen embed). 

## Any Breaking changes:
None

## Associated Screenshots:
    
<img width="1108" alt="Screenshot 2023-02-07 at 12 07 21 a m" src="https://user-images.githubusercontent.com/28614996/217115419-9505da6e-666c-434b-8cc8-c6caf36385b4.png">
