### PR TITLE
fix: inline code from overflowing in preview container

### DIFF
--- a/pages/create/[[...postIdArr]].tsx
+++ b/pages/create/[[...postIdArr]].tsx
@@ -431,7 +431,10 @@ const Create: NextPage = () => {
                           </h2>
                           <article
                             className="prose prose-invert"
-                            style={{ whiteSpace: "pre-wrap" }}
+                            style={{
+                              whiteSpace: "pre-wrap",
+                              overflowWrap: "anywhere",
+                            }}
                           >
                             {Markdoc.renderers.react(
                               Markdoc.transform(Markdoc.parse(body), config),


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

## Pull Request details:
Related issue: #155 

If a user inputted a long inline code they would of saw it overflowing outside of the the preview container/box.

In order to solve this issue, I had to add `overflowWrap: "anywhere"` into the style attribute for the article section.

## Any Breaking changes:

None

## Associated Screenshots:

![Nnqa8Nzh9K](https://user-images.githubusercontent.com/30472715/218259815-f80d6a04-c357-43c3-9bb5-3fe8542b18e7.png)