### PR TITLE
Add skip property to article list query

### DIFF
--- a/server/trpc/router/post.ts
+++ b/server/trpc/router/post.ts
@@ -262,6 +262,7 @@ export const postRouter = router({
         },
       },
       cursor: cursor ? { id: cursor } : undefined,
+      skip: cursor ? 1 : 0,
       orderBy: {
         published: "desc",
       },


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

Currently posts are repeating a post every time we fetch the posts from the database.

By adding skip to the query we can make sure we don't fetch the last post and only get the posts after the last one.  

Closes #165
