### PR TITLE
fix(anchor tags): add custom markdoc node to open links in a new tab …

### DIFF
--- a/markdoc/nodes/customLink.markdoc.ts
+++ b/markdoc/nodes/customLink.markdoc.ts
@@ -1,0 +1,42 @@
+import { Tag } from '@markdoc/markdoc';
+
+
+// creates a custom link node to add _blank and rel noopener to <a> tags
+// https://markdoc.dev/docs/nodes#customizing-markdoc-nodes
+
+const link = {
+    // Specify that the link node can only contain text as children
+  children: ['text'],
+  attributes: {
+    // original attributes
+    href: { type: String, required: true },
+    title: { type: String }
+  }, 
+  // now add custom attributes
+  // The transform method is used to customize the transformation of the link node.
+  // TODO: add types
+  transform(node, config) {
+     
+    const attributes = node.transformAttributes(config);
+    const children = node.transformChildren(config);
+    const href = attributes.href;
+
+    // Check if href has a protocol, if not add 'http://' by default
+    if (!/^(f|ht)tps?:\/\//i.test(href)) {
+      attributes.href = 'http://' + href;
+    }
+
+    return new Tag(
+      'a',
+      {
+        ...attributes,
+        target: '_blank',
+        rel: 'noopener'
+      },
+      children
+    );
+  }
+};
+
+
+export default link

--- a/markdoc/nodes/index.ts
+++ b/markdoc/nodes/index.ts
@@ -1,1 +1,2 @@
 export { default as fence } from "./Fence.markdoc"
+export { default as link } from "./customLink.markdoc"


### PR DESCRIPTION
closes #175 

# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

👉 _**Please remove the below and replace with your own values, leaving the headers where they are.**_ 👈

## Pull Request details:
- add a custom markdoc node that will alter anchor tags during the transform process to include target="_blank" rel noopener and also check/add href protocol if missing.

## Any Breaking changes:
none but should do som qa

## Associated Screenshots:
    
none