### PR TITLE
Dcallaghan/mediatag embed #158

### DIFF
--- a/components/markdocNodes/FallbackMedia/FallbackMedia.tsx
+++ b/components/markdocNodes/FallbackMedia/FallbackMedia.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+
+export function FallbackMedia(props: React.IframeHTMLAttributes<HTMLIFrameElement>) {
+  return (
+    <div>
+      <iframe {...props} />
+      <style >
+        {`
+          iframe {
+            width: 100%;
+            height: 600px;
+          }
+        `}
+      </style>
+    </div>
+  );
+}

--- a/components/markdocNodes/Media/Media.tsx
+++ b/components/markdocNodes/Media/Media.tsx
@@ -20,7 +20,7 @@ const getEmbedUrlRegex = () =>
   /^(?:https?:\/\/)?(?:www\.)?youtube\.com\/embed\/([\w-]{11})(?:\S+)?$/i;
 
 const getCodesandboxRegex = () =>
-  /^https?:\/\/codesandbox\.io\/s\/([\w-]+)(?:\?.*)?$/i;
+/^https?:\/\/codesandbox\.io\/(?:embed|s)\/([\w-]+)(?:\?.*)?$/i;
 
 const getCodepenRegex = () =>
   /^(?:https?:\/\/)?(?:www\.)?codepen\.io\/[\w-]+\/(?:embed|pen)\/([\w-]+)(?:\S+)?$/i;

--- a/components/markdocNodes/Media/Media.tsx
+++ b/components/markdocNodes/Media/Media.tsx
@@ -11,7 +11,7 @@ const codepenRegex = /{%\s*media\s*src="https?:\/\/codepen\.io\/([\w-]+)\/embed\
 
 export function Media(props: React.ReactPropTypes) {
 
-    const [type, setType] = React.useState('fallback')
+    // const [type, setType] = React.useState('fallback')
 
 
     const processMedia = (mediaProps) => {
@@ -29,9 +29,11 @@ export function Media(props: React.ReactPropTypes) {
       
       const processYoutube = (mediaProps) => {
         let src = checkProtocol(mediaProps.src)
+        const type = 'youtube'
         return {
             ...mediaProps,
             src,
+            type
         }
 
     }
@@ -39,7 +41,7 @@ export function Media(props: React.ReactPropTypes) {
       
       const processCodeSandbox = (mediaProps) => {
         let src = checkProtocol(mediaProps.src)
-        setType('codesandbox')
+        // setType('codesandbox')
         return {
             ...mediaProps,
             src,
@@ -49,7 +51,7 @@ export function Media(props: React.ReactPropTypes) {
       
       const processCodePen = (mediaProps) => {
         let src = checkProtocol(mediaProps.src)
-        setType('codepen')
+        // setType('codepen')
         return {
             ...mediaProps,
             src,
@@ -59,7 +61,7 @@ export function Media(props: React.ReactPropTypes) {
       
       const processFallback = (mediaProps) => {
         const src = checkProtocol(mediaProps.src);
-        setType('fallback')
+        // setType('fallback')
         return {
             ...mediaProps,
             src,
@@ -90,5 +92,5 @@ export function Media(props: React.ReactPropTypes) {
     
     const processedProps = processMedia(props)
     console.log(processedProps)
-    return renderMediaComponent(type, processedProps)
+    return renderMediaComponent(processedProps.type, processedProps)
 }

--- a/components/markdocNodes/Media/Media.tsx
+++ b/components/markdocNodes/Media/Media.tsx
@@ -1,96 +1,138 @@
-import * as React from 'react';
-import { YouTube } from '../Youtube/Youtube';
-import { CodePen } from '../Codepen/CodePen';
-import { CodeSandbox } from '../Codesandbox/CodeSandbox';
-import { FallbackMedia } from '../FallbackMedia/FallbackMedia';
+import * as React from "react";
+import { YouTube } from "../Youtube/Youtube";
+import { CodePen } from "../Codepen/CodePen";
+import { CodeSandbox } from "../Codesandbox/CodeSandbox";
+import { FallbackMedia } from "../FallbackMedia/FallbackMedia";
 
-const protocolRegex = /^(f|ht)tps?:\/\//i
-const youtubeRegex = /^(?:https?:\/\/)?(?:www\.)?(?:m\.)?(?:youtu\.be\/|youtube\.com\/(?:watch\?(?:feature=youtu\.be[&amp;]?|v=)|embed\/|v\/))([\w-]{11})(?:\S+)?$/;
-const codesandboxRegex = /{%\s*media\s*src="https?:\/\/codesandbox\.io\/embed\/([\w-]+).*?"\s*%}/i;
-const codepenRegex = /{%\s*media\s*src="https?:\/\/codepen\.io\/([\w-]+)\/embed\/([\w-]+).*?"\s*%}/i;
+
+interface MediaProps {
+  src: string;
+  type?: string;
+  width?: number | string;
+  height?: number | string;
+  alt?: string;
+}
+
+const getYoutubeRegex = () =>
+  /^(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/watch\?(?=.*v=\w+)|youtu\.be\/)([\w-]{11})(?:\S+)?$/i;
+
+const getEmbedUrlRegex = () =>
+  /^(?:https?:\/\/)?(?:www\.)?youtube\.com\/embed\/([\w-]{11})(?:\S+)?$/i;
+
+const getCodesandboxRegex = () =>
+  /^https?:\/\/codesandbox\.io\/s\/([\w-]+)(?:\?.*)?$/i;
+
+const getCodepenRegex = () =>
+  /^(?:https?:\/\/)?(?:www\.)?codepen\.io\/[\w-]+\/(?:embed|pen)\/([\w-]+)(?:\S+)?$/i;
+
+
+const protocolRegex = /^(f|ht)tps?:\/\//i;
+const youtubeRegex = getYoutubeRegex();
+const embedUrlRegex = getEmbedUrlRegex();
+const codesandboxRegex = getCodesandboxRegex();
+const codepenRegex = getCodepenRegex();
+
 
 export function Media(props: React.ReactPropTypes) {
 
-    // const [type, setType] = React.useState('fallback')
-    const type = React.useRef('fallback')
+  const MEDIA_TYPES = {
+  YOUTUBE: "youtube",
+  CODEPEN: "codepen",
+  CODESANDBOX: "codesandbox",
+  FALLBACK: "fallback",
+};
 
-    const processMedia = (mediaProps) => {
-        let match;
-        if ((match = mediaProps.src.match(youtubeRegex))) {
-          return processYoutube({...mediaProps});
-        } else if ((match = mediaProps.src.match(codesandboxRegex))) {
-          return processCodeSandbox({...mediaProps});
-        } else if ((match = mediaProps.src.match(codepenRegex))) {
-          return processCodePen({...mediaProps});
-        } else {
-          return processFallback({...mediaProps});
-        }
-      };
-      
-      const processYoutube = (mediaProps) => {
-        let src = checkProtocol(mediaProps.src)
-        type.current = 'youtube'
-        return {
-            ...mediaProps,
-            src,
-            type
-        }
+  // type is used to return a specif component in markdocNodes
+  const type = React.useRef(MEDIA_TYPES.FALLBACK);
 
+  const processMedia = (mediaProps: MediaProps) => {
+    // Regex test, parse the src url and determine which
+    // media type user is trying to use before we perform
+    // some operations. This is a necessary step because we we
+    // need to make sure src url is valid and also account for
+    // varying amounts of props for each component
+    let match;
+    switch (true) {
+      case Boolean((match = mediaProps.src.match(youtubeRegex))):
+        return processYoutube({ ...mediaProps });
+      case Boolean((match = mediaProps.src.match(codesandboxRegex))):
+        return processCodeSandbox({ ...mediaProps });
+      case Boolean((match = mediaProps.src.match(codepenRegex))):
+        return processCodePen({ ...mediaProps });
+      default:
+        return processFallback({ ...mediaProps });
     }
-    
-      
-      const processCodeSandbox = (mediaProps) => {
-        let src = checkProtocol(mediaProps.src)
-        // setType('codesandbox')
-        return {
-            ...mediaProps,
-            src,
-        }
+  };
 
-      }
-      
-      const processCodePen = (mediaProps) => {
-        let src = checkProtocol(mediaProps.src)
-        // setType('codepen')
-        return {
-            ...mediaProps,
-            src,
-        }
+  const processYoutube = (mediaProps: MediaProps) => {
+    let src = mediaProps.src
+    const isEmbedUrl = embedUrlRegex.test(src);
+    // If not, reformat the URL to the embed URL format
+    isEmbedUrl ? (src = checkProtocol(src)) : (src = formatEmbed(src));
+    type.current = MEDIA_TYPES.YOUTUBE;
+    return {
+      ...mediaProps,
+      src,
+    };
+  };
 
-      }
-      
-      const processFallback = (mediaProps) => {
-        const src = checkProtocol(mediaProps.src);
-        // setType('fallback')
-        return {
-            ...mediaProps,
-            src,
-        }
-      };
+  const processCodeSandbox = (mediaProps: MediaProps) => {
+    const src = checkProtocol(mediaProps.src);
+    type.current = MEDIA_TYPES.CODESANDBOX;
+    return {
+      ...mediaProps,
+      src,
+    };
+  };
 
-    const renderMediaComponent = (type: string, props: any) => {
-        switch(type) {
-          case 'youtube':
-            return <YouTube {...props} />;
-          case 'codepen':
-            return <CodePen {...props} />;
-          case 'codesandbox':
-            return <CodeSandbox {...props} />;
-          default:
-            return <FallbackMedia {...props} />;
-        }
-      }
-    
-      const checkProtocol = (url: string) => {
-        if(!protocolRegex.test(url)){
-            url = `https://${url}`
-        }
-        return url
-      }
-    
+  const processCodePen = (mediaProps: MediaProps) => {
+    const src = checkProtocol(mediaProps.src);
+    type.current = MEDIA_TYPES.CODEPEN;
+    return {
+      ...mediaProps,
+      src,
+    };
+  };
 
-    
-    const processedProps = processMedia(props)
-    console.log(processedProps)
-    return renderMediaComponent(type.current, processedProps)
+  const processFallback = (mediaProps: MediaProps) => {
+    const src = checkProtocol(mediaProps.src);
+    return {
+      ...mediaProps,
+      src,
+    };
+  };
+
+  // uses type.current and process props to render correct component
+  const renderMediaComponent = (type: string, props: any) => {
+    switch (type) {
+      case "youtube":
+        return <YouTube {...props} />;
+      case "codepen":
+        return <CodePen {...props} />;
+      case "codesandbox":
+        return <CodeSandbox {...props} />;
+      default:
+        return <FallbackMedia {...props} />;
+    }
+  };
+
+  // check for url protocol. if noe add http by default
+  const checkProtocol = (url: string) => {
+    if (!protocolRegex.test(url)) {
+      url = `http://${url}`;
+    }
+    return url;
+  };
+
+  // format youtube url if it is not embed format
+  // can happen when user copy and past direct from youtube url bar
+  const formatEmbed = (src: string) => {
+    const videoId = src.match(/(?:\?v=|&v=|youtu\.be\/)([\w-]{11})/)[1] || '';
+    src = `https://www.youtube.com/embed/${videoId}`;
+    return src;
+  };
+
+  const processedProps = processMedia(props);
+  console.log(processedProps);
+  return renderMediaComponent(type.current, processedProps);
 }

--- a/components/markdocNodes/Media/Media.tsx
+++ b/components/markdocNodes/Media/Media.tsx
@@ -65,18 +65,17 @@ export function Media(props: React.ReactPropTypes) {
   };
 
   const processYoutube = (mediaProps: MediaProps) => {
-    console.log('youtube...')
     const isEmbedUrl = embedUrlRegex.test(mediaProps.src);
     // If not, reformat the URL to the embed URL format
-    if(!isEmbedUrl){mediaProps.src = formatEmbed(mediaProps.src)}
+    const src = isEmbedUrl ? mediaProps.src : formatEmbed(mediaProps.src);
     type.current = MEDIA_TYPES.YOUTUBE;
     return {
-      ...mediaProps
+      ...mediaProps,
+      src
     };
   };
 
   const processCodeSandbox = (mediaProps: MediaProps) => {
-    console.log('code sandbox...')
     type.current = MEDIA_TYPES.CODESANDBOX;
     return {
       ...mediaProps,
@@ -84,7 +83,6 @@ export function Media(props: React.ReactPropTypes) {
   };
 
   const processCodePen = (mediaProps: MediaProps) => {
-    console.log('code pen...')
     type.current = MEDIA_TYPES.CODEPEN;
     return {
       ...mediaProps,
@@ -92,7 +90,6 @@ export function Media(props: React.ReactPropTypes) {
   };
 
   const processFallback = (mediaProps: MediaProps) => {
-    console.log('fallback...')
     return {
       ...mediaProps,
     };

--- a/components/markdocNodes/Media/Media.tsx
+++ b/components/markdocNodes/Media/Media.tsx
@@ -12,7 +12,7 @@ const codepenRegex = /{%\s*media\s*src="https?:\/\/codepen\.io\/([\w-]+)\/embed\
 export function Media(props: React.ReactPropTypes) {
 
     // const [type, setType] = React.useState('fallback')
-
+    const type = React.useRef('fallback')
 
     const processMedia = (mediaProps) => {
         let match;
@@ -29,7 +29,7 @@ export function Media(props: React.ReactPropTypes) {
       
       const processYoutube = (mediaProps) => {
         let src = checkProtocol(mediaProps.src)
-        const type = 'youtube'
+        type.current = 'youtube'
         return {
             ...mediaProps,
             src,
@@ -92,5 +92,5 @@ export function Media(props: React.ReactPropTypes) {
     
     const processedProps = processMedia(props)
     console.log(processedProps)
-    return renderMediaComponent(processedProps.type, processedProps)
+    return renderMediaComponent(type.current, processedProps)
 }

--- a/components/markdocNodes/Media/Media.tsx
+++ b/components/markdocNodes/Media/Media.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react';
+import { YouTube } from '../Youtube/Youtube';
+import { CodePen } from '../Codepen/CodePen';
+import { CodeSandbox } from '../Codesandbox/CodeSandbox';
+import { FallbackMedia } from '../FallbackMedia/FallbackMedia';
+
+const protocolRegex = /^(f|ht)tps?:\/\//i
+const youtubeRegex = /^(?:https?:\/\/)?(?:www\.)?(?:m\.)?(?:youtu\.be\/|youtube\.com\/(?:watch\?(?:feature=youtu\.be[&amp;]?|v=)|embed\/|v\/))([\w-]{11})(?:\S+)?$/;
+const codesandboxRegex = /{%\s*media\s*src="https?:\/\/codesandbox\.io\/embed\/([\w-]+).*?"\s*%}/i;
+const codepenRegex = /{%\s*media\s*src="https?:\/\/codepen\.io\/([\w-]+)\/embed\/([\w-]+).*?"\s*%}/i;
+
+export function Media(props: React.ReactPropTypes) {
+
+    const [type, setType] = React.useState('fallback')
+
+
+    const processMedia = (mediaProps) => {
+        let match;
+        if ((match = mediaProps.src.match(youtubeRegex))) {
+          return processYoutube({...mediaProps});
+        } else if ((match = mediaProps.src.match(codesandboxRegex))) {
+          return processCodeSandbox({...mediaProps});
+        } else if ((match = mediaProps.src.match(codepenRegex))) {
+          return processCodePen({...mediaProps});
+        } else {
+          return processFallback({...mediaProps});
+        }
+      };
+      
+      const processYoutube = (mediaProps) => {
+        let src = checkProtocol(mediaProps.src)
+        return {
+            ...mediaProps,
+            src,
+        }
+
+    }
+    
+      
+      const processCodeSandbox = (mediaProps) => {
+        let src = checkProtocol(mediaProps.src)
+        setType('codesandbox')
+        return {
+            ...mediaProps,
+            src,
+        }
+
+      }
+      
+      const processCodePen = (mediaProps) => {
+        let src = checkProtocol(mediaProps.src)
+        setType('codepen')
+        return {
+            ...mediaProps,
+            src,
+        }
+
+      }
+      
+      const processFallback = (mediaProps) => {
+        const src = checkProtocol(mediaProps.src);
+        setType('fallback')
+        return {
+            ...mediaProps,
+            src,
+        }
+      };
+
+    const renderMediaComponent = (type: string, props: any) => {
+        switch(type) {
+          case 'youtube':
+            return <YouTube {...props} />;
+          case 'codepen':
+            return <CodePen {...props} />;
+          case 'codesandbox':
+            return <CodeSandbox {...props} />;
+          default:
+            return <FallbackMedia {...props} />;
+        }
+      }
+    
+      const checkProtocol = (url: string) => {
+        if(!protocolRegex.test(url)){
+            url = `https://${url}`
+        }
+        return url
+      }
+    
+
+    
+    const processedProps = processMedia(props)
+    console.log(processedProps)
+    return renderMediaComponent(type, processedProps)
+}

--- a/components/markdocNodes/Media/Media.tsx
+++ b/components/markdocNodes/Media/Media.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { YouTube } from "../Youtube/Youtube";
-import { CodePen } from "../Codepen/CodePen";
-import { CodeSandbox } from "../Codesandbox/CodeSandbox";
+import { CodePen } from "../CodePen/CodePen";
+import { CodeSandbox } from "../CodeSandbox/CodeSandbox";
 import { FallbackMedia } from "../FallbackMedia/FallbackMedia";
 
 

--- a/components/markdocNodes/Media/Media.tsx
+++ b/components/markdocNodes/Media/Media.tsx
@@ -126,6 +126,5 @@ export function Media(props: React.ReactPropTypes) {
   };
 
   const processedProps = processMedia(props);
-  console.log(processedProps);
   return renderMediaComponent(type.current, processedProps);
 }

--- a/components/markdocNodes/Media/Media.tsx
+++ b/components/markdocNodes/Media/Media.tsx
@@ -14,7 +14,7 @@ interface MediaProps {
 }
 
 const getYoutubeRegex = () =>
-  /^(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/watch\?(?=.*v=\w+)|youtu\.be\/)([\w-]{11})(?:\S+)?$/i;
+/^(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/(?:watch\?(?=.*v=\w+)|embed\/)|youtu\.be\/)/i;
 
 const getEmbedUrlRegex = () =>
   /^(?:https?:\/\/)?(?:www\.)?youtube\.com\/embed\/([\w-]{11})(?:\S+)?$/i;
@@ -46,59 +46,55 @@ export function Media(props: React.ReactPropTypes) {
   const type = React.useRef(MEDIA_TYPES.FALLBACK);
 
   const processMedia = (mediaProps: MediaProps) => {
+    const src = checkProtocol(mediaProps.src);
     // Regex test, parse the src url and determine which
     // media type user is trying to use before we perform
     // some operations. This is a necessary step because we we
     // need to make sure src url is valid and also account for
     // varying amounts of props for each component
-    let match;
     switch (true) {
-      case Boolean((match = mediaProps.src.match(youtubeRegex))):
-        return processYoutube({ ...mediaProps });
-      case Boolean((match = mediaProps.src.match(codesandboxRegex))):
-        return processCodeSandbox({ ...mediaProps });
-      case Boolean((match = mediaProps.src.match(codepenRegex))):
-        return processCodePen({ ...mediaProps });
+      case !!mediaProps.src.match(youtubeRegex):
+        return processYoutube({ ...mediaProps, src });
+      case !!mediaProps.src.match(codesandboxRegex):
+        return processCodeSandbox({ ...mediaProps, src });
+      case !!mediaProps.src.match(codepenRegex):
+        return processCodePen({ ...mediaProps, src });
       default:
-        return processFallback({ ...mediaProps });
+        return processFallback({ ...mediaProps, src });
     }
   };
 
   const processYoutube = (mediaProps: MediaProps) => {
-    let src = mediaProps.src
-    const isEmbedUrl = embedUrlRegex.test(src);
+    console.log('youtube...')
+    const isEmbedUrl = embedUrlRegex.test(mediaProps.src);
     // If not, reformat the URL to the embed URL format
-    isEmbedUrl ? (src = checkProtocol(src)) : (src = formatEmbed(src));
+    if(!isEmbedUrl){mediaProps.src = formatEmbed(mediaProps.src)}
     type.current = MEDIA_TYPES.YOUTUBE;
     return {
-      ...mediaProps,
-      src,
+      ...mediaProps
     };
   };
 
   const processCodeSandbox = (mediaProps: MediaProps) => {
-    const src = checkProtocol(mediaProps.src);
+    console.log('code sandbox...')
     type.current = MEDIA_TYPES.CODESANDBOX;
     return {
       ...mediaProps,
-      src,
     };
   };
 
   const processCodePen = (mediaProps: MediaProps) => {
-    const src = checkProtocol(mediaProps.src);
+    console.log('code pen...')
     type.current = MEDIA_TYPES.CODEPEN;
     return {
       ...mediaProps,
-      src,
     };
   };
 
   const processFallback = (mediaProps: MediaProps) => {
-    const src = checkProtocol(mediaProps.src);
+    console.log('fallback...')
     return {
       ...mediaProps,
-      src,
     };
   };
 

--- a/markdoc/components.ts
+++ b/markdoc/components.ts
@@ -2,10 +2,12 @@ import Code from "../components/markdocNodes/Code/Code";
 import { CodePen } from "../components/markdocNodes/CodePen/CodePen";
 import { CodeSandbox } from "../components/markdocNodes/CodeSandbox/CodeSandbox";
 import { YouTube } from "../components/markdocNodes/Youtube/Youtube";
+import { Media } from "../components/markdocNodes/Media/Media";
 
 export const markdocComponents = {
   Code,
   CodePen,
   Youtube: YouTube,
   CodeSandbox: CodeSandbox,
+  Media: Media
 };

--- a/markdoc/tags/index.ts
+++ b/markdoc/tags/index.ts
@@ -1,5 +1,6 @@
 module.exports['markdoc-example'] = markdocExample;
 export { default as codepen } from './codepen.markdoc';
 export { default as youtube } from './youtube.markdoc';
+export { default as media } from './mediatag.markdoc';
 export { default as codesandbox } from './codesandbox.markdoc';
 import markdocExample from './markdoc-example.markdoc';

--- a/markdoc/tags/mediatag.markdoc.tsx
+++ b/markdoc/tags/mediatag.markdoc.tsx
@@ -1,0 +1,14 @@
+import { Media } from "../../components/markdocNodes/Media/Media";
+
+const media = {
+  render: "Media",
+  component: Media,
+  attributes: {
+    src: {
+      type: String,
+      required: true,
+    },
+  },
+};
+
+export default media;


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

👉 _**Please remove the below and replace with your own values, leaving the headers where they are.**_ 👈

## Pull Request details:
Updates custom tags to work in one general media tag, user can now use {% media src="src-to-embed" /%} for youtube, codepen, code sandbox and will fallback to generic iframe if not one of those types. Add some checking for youtube incase user copy link from url bar and not from embed link. both should work now.

## Any Breaking changes:
- none, user can still use old tags or this new tag, both will work

## Associated Screenshots:
    
can manually test with:

Youtube

{% media src="https://www.youtube.com/watch?v=7mmlmxamw_k" /%}


{% media src="www.youtube.com/watch?v=7mmlmxamw_k" /%}


{% media src="https://youtu.be/7mmlmxamw_k" /%}

{% media src="youtu.be/7mmlmxamw_k" /%}


Code Sandbox
{% media src="https://codesandbox.io/embed/vanilla-vanilla?fontsize=14&hidenavigation=1&theme=dark" / %}

{% media src="https://codesandbox.io/s/vanilla-vanilla" /%}

Codepen

{% codepen src="https://codepen.io/yuanchuan/pen/dyqYYBN" /%}

{% media src="codepen.io/yuanchuan/pen/dyqYYBN" /%}

Fallback

{% media src="https://www.codu.co/" /%}
{% media src="www.codu.co/" / %}