### PR TITLE
fix(media tags): fix for aspect ratio bug caused by overriding style …

### DIFF
--- a/components/markdocNodes/CodeSandbox/CodeSandbox.tsx
+++ b/components/markdocNodes/CodeSandbox/CodeSandbox.tsx
@@ -2,24 +2,14 @@ import * as React from "react";
 
 export function CodeSandbox(props: React.ReactPropTypes) {
   return (
-    <div>
+    <div style={{marginInline: '16px 0px'}}>
       <iframe
         {...props}
         frameBorder="0"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
         allowFullScreen
+        style={{width: '100%', aspectRatio: '16 / 9'}}
       />
-      <style jsx>
-        {`
-          div {
-            margin: 16px 0px;
-          }
-          iframe {
-            width: 100%;
-            aspect-ratio: 16 / 9;
-          }
-        `}
-      </style>
     </div>
   );
 }

--- a/components/markdocNodes/FallbackMedia/FallbackMedia.tsx
+++ b/components/markdocNodes/FallbackMedia/FallbackMedia.tsx
@@ -3,15 +3,7 @@ import * as React from 'react';
 export function FallbackMedia(props: React.IframeHTMLAttributes<HTMLIFrameElement>) {
   return (
     <div>
-      <iframe {...props} />
-      <style >
-        {`
-          iframe {
-            width: 100%;
-            height: 600px;
-          }
-        `}
-      </style>
+      <iframe style={{width: '100%', height: '300px'}} {...props} /> 
     </div>
   );
 }

--- a/components/markdocNodes/Youtube/Youtube.tsx
+++ b/components/markdocNodes/Youtube/Youtube.tsx
@@ -8,15 +8,8 @@ export function YouTube(props: React.ReactPropTypes) {
         frameBorder="0"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
         allowFullScreen
+        style={{width: '100%', aspectRatio: '16 / 9'}}
       />
-      <style jsx>
-        {`
-          iframe {
-            width: 100%;
-            aspect-ratio: 16 / 9;
-          }
-        `}
-      </style>
     </div>
   );
 }


### PR DESCRIPTION
…tags - process custom tag links if not correct format #189

# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

👉 _**Please remove the below and replace with your own values, leaving the headers where they are.**_ 👈

## Pull Request details:
Fixes aspect ratio bugs on media tags. Styles for each iframe were being set globally in <style> tag. This is dangerous because a style in one iframe can cause unwanted side effects in other iframes in the post. 

## Any Breaking changes:
none

## Associated Screenshots:
    
_( Welcome file extensions include gifs/png screenshots of your feature in action )_

none