### PR TITLE
Added missing protocol in og:url meta tag for Articles

### DIFF
--- a/pages/articles/[slug].tsx
+++ b/pages/articles/[slug].tsx
@@ -102,7 +102,7 @@ const ArticlePage: NextPage = ({
         <meta name="msapplication-config" content="browserconfig.xml" />
         <meta name="theme-color" content="#000" />
         <meta property="og:type" content="article" />
-        <meta property="og:url" content={`${host}/articles/${post.slug}`} />
+        <meta property="og:url" content={`https://${host}/articles/${post.slug}`} />
         <meta
           name="image"
           property="og:image"


### PR DESCRIPTION
Missing the protocol might lead crawlers to think this is a relative URL. For example the FullStack bulletin crawler picked up an article URL as follows:

![Screenshot 2023-03-18 at 10 59 17](https://user-images.githubusercontent.com/205629/226101792-9c015bab-cc90-4e79-9dba-78ed8fd918d8.png)

This might also break previews for when articles are shared on social websites such as Twitter, Linkedin and Facebook.

For instance, Linkedin picks this up as HTTP:

![Screenshot 2023-03-18 at 11 14 20](https://user-images.githubusercontent.com/205629/226101907-b72366a0-d418-4983-a484-132809e54c90.png)

While Twitter doesn't seem to pick up the preview picture (not necessarily related but worth investigating too after this is fixed):

![Screenshot 2023-03-18 at 11 15 02](https://user-images.githubusercontent.com/205629/226101942-99c3fe22-f290-41c4-b31c-2585c2ecc3d8.png)