### PR TITLE
fix: excerpt now generated from body if not provided

### DIFF
--- a/pages/create/[[...postIdArr]].tsx
+++ b/pages/create/[[...postIdArr]].tsx
@@ -119,7 +119,7 @@ const Create: NextPage = () => {
       ...data,
       tags,
       canonicalUrl: data.canonicalUrl || undefined,
-      excerpt: data.excerpt || removeMarkdown(data.body.substring(0, 155), {}),
+      excerpt: data.excerpt || removeMarkdown(data.body, {}).substring(0, 155),
     };
     return formData;
   };

--- a/pages/create/[[...postIdArr]].tsx
+++ b/pages/create/[[...postIdArr]].tsx
@@ -16,6 +16,7 @@ import Layout from "../../components/Layout/Layout";
 import { PromptDialog } from "../../components/PromptService/PromptService";
 
 import { trpc } from "../../utils/trpc";
+import { removeMarkdown } from "../../utils/removeMarkdown";
 import { useDebounce } from "../../hooks/useDebounce";
 import Markdoc from "@markdoc/markdoc";
 import { useMarkdownHotkeys } from "../../markdoc/editor/hotkeys/hotkeys.markdoc";
@@ -118,7 +119,7 @@ const Create: NextPage = () => {
       ...data,
       tags,
       canonicalUrl: data.canonicalUrl || undefined,
-      excerpt: data.excerpt || undefined,
+      excerpt: data.excerpt || removeMarkdown(data.body.substring(0, 155), {}),
     };
     return formData;
   };


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)


## Pull Request details:
Closes #259

Previously if the except text box was left blank the article would have no excerpt saved in the DB.

If the exceprt is not provided, This change will remove the markdown from the body and set the first 156 chars of the article as the default.

Note: I didnt populate the excerpt text box by default after clicking "Publish". This is to provide the user with the opportunity to write their own excerpt without having to delete the default one. Maybe this should be changed?

## Any breaking changes
None
## Associated Screenshots:
    
![image](https://github.com/codu-code/codu/assets/46611809/0f391408-824b-439e-917b-de730882f526)
New article being written.

![image](https://github.com/codu-code/codu/assets/46611809/e061b3df-6805-43c6-a980-e36891ac20fc)
After clicking publish. Note no excerpt in text box

![image](https://github.com/codu-code/codu/assets/46611809/087b38f6-d092-4c2f-87f6-b0fb21252e98)
After clicking Publish again and navigating to Articles page. Note default excerpt generated

![image](https://github.com/codu-code/codu/assets/46611809/6f13e2aa-c196-4058-9450-32db11e0b403)
Second article being created

![image](https://github.com/codu-code/codu/assets/46611809/6f280da4-a875-4dff-a9ff-b82df6b207c5)
Excerpt populated

![image](https://github.com/codu-code/codu/assets/46611809/d2b31fe0-cb57-44a8-a91f-0cdc17d6e542)
After clicking Publish again and navigating to Articles page. Note actual excerpt provided by user is used instead of default

