### PR TITLE
feat: added new props to prompt service and updated style to match site

### DIFF
--- a/components/Modal/Modal.tsx
+++ b/components/Modal/Modal.tsx
@@ -34,7 +34,7 @@ export function Modal({ open, onClose, children }: Props) {
               leaveFrom="opacity-100 translate-y-0 sm:scale-100"
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
-              <Dialog.Panel className="relative bg-white border-2 border-black px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:max-w-lg sm:w-full sm:p-6">
+              <Dialog.Panel className="relative bg-neutral-900 border-2 border-black px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:max-w-lg sm:w-full sm:p-6">
                 {children}
               </Dialog.Panel>
             </Transition.Child>

--- a/components/PromptService/PromptService.tsx
+++ b/components/PromptService/PromptService.tsx
@@ -1,17 +1,23 @@
 import { useRouter } from "next/router";
 import React, { useState, useEffect, useCallback } from "react";
 import { Modal } from "../Modal/Modal";
-import { ExclamationIcon, XIcon } from "@heroicons/react/outline";
+import { ExclamationIcon, PlusSmIcon, XIcon } from "@heroicons/react/outline";
 import { Dialog } from "@headlessui/react";
 
 export interface serviceProps {
   shouldConfirmLeave: boolean;
   updateParent: (...args: any[]) => any;
+  title: string;
+  subTitle: string;
+  content?: string;
 }
 
 export const PromptDialog = ({
   updateParent,
   shouldConfirmLeave,
+  title,
+  subTitle,
+  content,
 }: serviceProps): React.ReactElement<serviceProps> => {
   const [showPromptDialog, setshowPromptDialog] = useState(false);
   const [nextRouterPath, setNextRouterPath] = useState<string>();
@@ -36,7 +42,7 @@ export const PromptDialog = ({
 
   const cancelRouteChange = () => {
     updateParent("cancel");
-    setNextRouterPath(null);
+    setNextRouterPath(undefined);
     setshowPromptDialog(false);
   };
 
@@ -44,7 +50,7 @@ export const PromptDialog = ({
     updateParent("confirm");
     setshowPromptDialog(false);
     removeListener();
-    router.push(nextRouterPath);
+    if (nextRouterPath) router.push(nextRouterPath);
   };
 
   const removeListener = () => {
@@ -61,7 +67,7 @@ export const PromptDialog = ({
       <div className="hidden sm:block absolute top-0 right-0 pt-4 pr-4">
         <button
           type="button"
-          className="bg-white text-neutral-400 hover:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+          className="bg-neutral-900 text-neutral-400 hover:text-neutral-500 focus:outline-none"
           onClick={cancelRouteChange}
         >
           <span className="sr-only">Close</span>
@@ -69,44 +75,42 @@ export const PromptDialog = ({
         </button>
       </div>
       <div className="sm:flex sm:items-start">
-        <div className="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
+        <div className="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-gradient-to-r from-orange-400 to-pink-600 sm:mx-0 sm:h-10 sm:w-10">
           <ExclamationIcon
-            className="h-6 w-6 text-red-600"
+            className="h-6 w-6 text-white-600 "
             aria-hidden="true"
           />
         </div>
         <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
           <Dialog.Title
             as="h3"
-            className="text-lg leading-6 font-medium text-black"
+            className="text-lg leading-6 font-medium text-white"
           >
-            Unsaved Changes
+            {title}
           </Dialog.Title>
           <div className="mt-2">
-            <p className="text-sm text-neutral-500">
-              You have unsaved changes.
-            </p>
-            <p className="text-sm text-neutral-500 mt-2">
-              Changes that you have made will be lost.
-            </p>
+            <p className="text-sm text-neutral-500">{subTitle}</p>
+            {content && (
+              <p className="text-sm text-neutral-500 mt-2">{content}</p>
+            )}
           </div>
         </div>
       </div>
       <div className="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
         <button
+          className="ml-4 primary-button"
           type="button"
           disabled={false}
-          className="w-full inline-flex justify-center border border-transparent shadow-sm px-4 py-2 bg-red-600 text-base font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 sm:ml-3 sm:w-auto sm:text-sm"
           onClick={confirmRouteChange}
         >
           Continue without saving
         </button>
         <button
           type="button"
-          className="mt-3 w-full inline-flex justify-center border border-neutral-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-neutral-700 hover:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:w-auto sm:text-sm"
+          className="rounded-md mt-3 w-full inline-flex justify-center border border-neutral-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-neutral-700 hover:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:w-auto sm:text-sm"
           onClick={cancelRouteChange}
         >
-          keep editing
+          Keep editing
         </button>
       </div>
     </Modal>

--- a/pages/create/[[...postIdArr]].tsx
+++ b/pages/create/[[...postIdArr]].tsx
@@ -264,6 +264,9 @@ const Create: NextPage = () => {
         <PromptDialog
           shouldConfirmLeave={unsavedChanges}
           updateParent={handleOpenDialog}
+          title="Unsaved Changes"
+          subTitle="You have unsaved changes."
+          content="Changes that you have made will be lost."
         />
         <form onSubmit={handleSubmit(onSubmit)}>
           <Transition.Root show={open} as={Fragment}>

--- a/pages/my-posts/index.tsx
+++ b/pages/my-posts/index.tsx
@@ -74,7 +74,7 @@ const MyPosts: NextPage = ({
         <div className="hidden sm:block absolute top-0 right-0 pt-4 pr-4">
           <button
             type="button"
-            className="bg-white text-neutral-400 hover:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+            className="bg-neutral-900 text-neutral-400 hover:text-neutral-500 focus:outline-none"
             onClick={() => setSelectedArticleToDelete(undefined)}
           >
             <span className="sr-only">Close</span>
@@ -82,16 +82,16 @@ const MyPosts: NextPage = ({
           </button>
         </div>
         <div className="sm:flex sm:items-start">
-          <div className="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
+          <div className="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-gradient-to-r from-orange-400 to-pink-600 sm:mx-0 sm:h-10 sm:w-10">
             <ExclamationIcon
-              className="h-6 w-6 text-red-600"
+              className="h-6 w-6 text-white-600"
               aria-hidden="true"
             />
           </div>
           <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
             <Dialog.Title
               as="h3"
-              className="text-lg leading-6 font-medium text-black"
+              className="text-lg leading-6 font-medium text-white"
             >
               Delete article
             </Dialog.Title>
@@ -110,7 +110,7 @@ const MyPosts: NextPage = ({
           <button
             type="button"
             disabled={deleteStatus === "loading"}
-            className="w-full inline-flex justify-center border border-transparent shadow-sm px-4 py-2 bg-red-600 text-base font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 sm:ml-3 sm:w-auto sm:text-sm"
+            className="ml-4 primary-button"
             onClick={() => {
               if (selectedArticleToDelete)
                 mutate({ id: selectedArticleToDelete });
@@ -120,7 +120,7 @@ const MyPosts: NextPage = ({
           </button>
           <button
             type="button"
-            className="mt-3 w-full inline-flex justify-center border border-neutral-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-neutral-700 hover:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:w-auto sm:text-sm"
+            className="mt-3 rounded-md w-full inline-flex justify-center border border-neutral-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-neutral-700 hover:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:w-auto sm:text-sm"
             onClick={() => setSelectedArticleToDelete(undefined)}
           >
             Cancel


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)


## Pull Request details:
Closes #203 

This generalises the prompt factor a small bit.

Allows us to change the text displayed in the prompt through props.
This will allow this component to be reused in the future to support prevent moving away from other types of unsaved changes.

In addition to this. I took the opportunity while i was in the component to more closely align the styling with the rest of the white. This is entirely reversible if we do not want to go with the style changes.

Given I needed to change the bg colour for the modal component which was also being used for the delete article confirm check. I needed to also update the style there.

## Any Breaking changes:
Yes, if someone has a dev branch and is using the prompt service this will be a breaking change when they sync with develop.

I have fixed the breaking change within [[...postIdArr]].tsx for pages/create.

## Associated Screenshots:

   Prompt Service before changes
<img width="762" alt="image" src="https://github.com/codu-code/codu/assets/46611809/10d36268-31ed-4dec-a7f0-e2bfe5293375">
   Prompt Service after changes
<img width="762" alt="image" src="https://github.com/codu-code/codu/assets/46611809/50808154-8f60-4598-882d-7467c6b9f4c1">
   Delete article prompt before changes
<img width="762" alt="image" src="https://github.com/codu-code/codu/assets/46611809/51be916d-1e0b-4ecc-946a-a95d051cf1ea">
   Delete article prompt after changes
<img width="762" alt="image" src="https://github.com/codu-code/codu/assets/46611809/8d2b4fab-f4d2-406a-9d36-b6985e4d87ee">

***Note : They are the same size in all screenshots just different zoom levels I think***