### PR TITLE
chore: added canonical link if its in the article

### DIFF
--- a/pages/articles/[slug].tsx
+++ b/pages/articles/[slug].tsx
@@ -117,6 +117,7 @@ const ArticlePage: NextPage = ({
     <>
       <Head>
         <title>{post.title}</title>
+        {post.canonicalUrl && <link rel="canonical" href={post.canonicalUrl} />}
         <meta name="author" content={post.user.name}></meta>
         <meta key="og:title" property="og:title" content={post.title} />
         <meta
@@ -225,31 +226,33 @@ const ArticlePage: NextPage = ({
       </Transition>
 
       <Layout>
-        <div className="mx-auto pb-4 max-w-3xl px-2 sm:px-4 break-words">
-          <article className="prose prose-invert lg:prose-lg">
-            <h1>{post.title}</h1>
-            {Markdoc.renderers.react(content, React, {
-              components: markdocComponents,
-            })}
-          </article>
-          {post.tags.length > 0 && (
-            <section className="flex flex-wrap gap-3">
-              {post.tags.map(({ tag }) => (
-                <Link
-                  href={`/articles?tag=${tag.title.toLowerCase()}`}
-                  key={tag.title}
-                  className="bg-gradient-to-r from-orange-400 to-pink-600 hover:bg-pink-700 text-white py-1 px-3 rounded-full text-xs font-bold"
-                >
-                  {tag.title}
-                </Link>
-              ))}
-            </section>
-          )}
-        </div>
-        <div className="mx-auto pb-4 max-w-3xl px-2 sm:px-4">
-          <BioBar author={post.user} />
-          <CommentsArea postId={post.id} postOwnerId={post.userId} />
-        </div>
+        <>
+          <div className="mx-auto pb-4 max-w-3xl px-2 sm:px-4 break-words">
+            <article className="prose prose-invert lg:prose-lg">
+              <h1>{post.title}</h1>
+              {Markdoc.renderers.react(content, React, {
+                components: markdocComponents,
+              })}
+            </article>
+            {post.tags.length > 0 && (
+              <section className="flex flex-wrap gap-3">
+                {post.tags.map(({ tag }) => (
+                  <Link
+                    href={`/articles?tag=${tag.title.toLowerCase()}`}
+                    key={tag.title}
+                    className="bg-gradient-to-r from-orange-400 to-pink-600 hover:bg-pink-700 text-white py-1 px-3 rounded-full text-xs font-bold"
+                  >
+                    {tag.title}
+                  </Link>
+                ))}
+              </section>
+            )}
+          </div>
+          <div className="mx-auto pb-4 max-w-3xl px-2 sm:px-4">
+            <BioBar author={post.user} />
+            <CommentsArea postId={post.id} postOwnerId={post.userId} />
+          </div>
+        </>
       </Layout>
     </>
   );

--- a/pages/articles/[slug].tsx
+++ b/pages/articles/[slug].tsx
@@ -226,33 +226,31 @@ const ArticlePage: NextPage = ({
       </Transition>
 
       <Layout>
-        <>
-          <div className="mx-auto pb-4 max-w-3xl px-2 sm:px-4 break-words">
-            <article className="prose prose-invert lg:prose-lg">
-              <h1>{post.title}</h1>
-              {Markdoc.renderers.react(content, React, {
-                components: markdocComponents,
-              })}
-            </article>
-            {post.tags.length > 0 && (
-              <section className="flex flex-wrap gap-3">
-                {post.tags.map(({ tag }) => (
-                  <Link
-                    href={`/articles?tag=${tag.title.toLowerCase()}`}
-                    key={tag.title}
-                    className="bg-gradient-to-r from-orange-400 to-pink-600 hover:bg-pink-700 text-white py-1 px-3 rounded-full text-xs font-bold"
-                  >
-                    {tag.title}
-                  </Link>
-                ))}
-              </section>
-            )}
-          </div>
-          <div className="mx-auto pb-4 max-w-3xl px-2 sm:px-4">
-            <BioBar author={post.user} />
-            <CommentsArea postId={post.id} postOwnerId={post.userId} />
-          </div>
-        </>
+        <div className="mx-auto pb-4 max-w-3xl px-2 sm:px-4 break-words">
+          <article className="prose prose-invert lg:prose-lg">
+            <h1>{post.title}</h1>
+            {Markdoc.renderers.react(content, React, {
+              components: markdocComponents,
+            })}
+          </article>
+          {post.tags.length > 0 && (
+            <section className="flex flex-wrap gap-3">
+              {post.tags.map(({ tag }) => (
+                <Link
+                  href={`/articles?tag=${tag.title.toLowerCase()}`}
+                  key={tag.title}
+                  className="bg-gradient-to-r from-orange-400 to-pink-600 hover:bg-pink-700 text-white py-1 px-3 rounded-full text-xs font-bold"
+                >
+                  {tag.title}
+                </Link>
+              ))}
+            </section>
+          )}
+        </div>
+        <div className="mx-auto pb-4 max-w-3xl px-2 sm:px-4">
+          <BioBar author={post.user} />
+          <CommentsArea postId={post.id} postOwnerId={post.userId} />
+        </div>
       </Layout>
     </>
   );


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)


## Pull Request details:
Closes #283 

This PR adds a canonical url to the head tag of articles if one is specified when creating the article.

If no canonical url is specified then none will be added to the head tag of the article page.

## Any Breaking changes:
None

## Associated Screenshots:

Define Canonical URL when creating article
<img width="1252" alt="image" src="https://github.com/codu-code/codu/assets/46611809/cf244fc9-4434-4f3e-a9af-760d887e8260">
See it present in the head element when you open the article page
<img width="1191" alt="image" src="https://github.com/codu-code/codu/assets/46611809/50e6f107-0f12-4771-a1b2-4150470f68c2">
 