### PR TITLE
Improve images on sponsorship page, add padding to notification page title

### DIFF
--- a/pages/alpha/sponsorship/index.tsx
+++ b/pages/alpha/sponsorship/index.tsx
@@ -4,7 +4,7 @@ import Layout from "../../../components/Layout/Layout";
 import Image from "next/image";
 import Link from "next/link";
 import Head from "next/head";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 interface Image {
   rotate: number;
@@ -41,16 +41,15 @@ const images: Image[] = [
 ];
 
 const Sponsorship: NextPage = () => {
-  const [scroll, setScroll] = useState(0);
-
   useEffect(() => {
     function handleScroll() {
-      setScroll(window.scrollY);
+      document.body.style.setProperty('--scroll', String(window.scrollY));
     }
     window.addEventListener("scroll", handleScroll);
 
     return () => {
       window.removeEventListener("scroll", handleScroll);
+      document.body.style.removeProperty('--scroll');
     };
   }, []);
 
@@ -73,16 +72,12 @@ const Sponsorship: NextPage = () => {
             </h3>
           </header>
           <section className="flex items-center relative bottom-12 justify-center overflow-hidden gap-8 sm:gap-20 sm:bottom-20 md:bottom-24  md:gap-36 lg:gap-44">
-            {images.map((image, id) => (
+            {images.map((image) => (
               <div
-                key={id}
+                key={image.src}
                 className={`w-32`}
                 style={{
-                  transform: `${
-                    scroll < 200
-                      ? `rotate(${(scroll / 200) * image.rotate}deg)`
-                      : `rotate(${image.rotate}deg)`
-                  }`,
+                  transform: `rotate(calc(min(var(--scroll), 200) / 200 * ${image.rotate}deg))`
                 }}
               >
                 <Image

--- a/pages/alpha/sponsorship/index.tsx
+++ b/pages/alpha/sponsorship/index.tsx
@@ -57,7 +57,7 @@ const Sponsorship: NextPage = () => {
   return (
     <>
       <Head>
-        <meta name="robots" content="noindex" />    
+        <meta name="robots" content="noindex" />
       </Head>
       <Layout>
         <div>
@@ -69,7 +69,7 @@ const Sponsorship: NextPage = () => {
               </b>
             </h1>
             <h3 className="text-lg font-bold">
-              Reach thousands of developers every mounth!
+              Reach thousands of developers every month!
             </h3>
           </header>
           <section className="flex items-center relative bottom-12 justify-center overflow-hidden gap-8 sm:gap-20 sm:bottom-20 md:bottom-24  md:gap-36 lg:gap-44">

--- a/pages/alpha/sponsorship/index.tsx
+++ b/pages/alpha/sponsorship/index.tsx
@@ -1,40 +1,47 @@
 import type { NextPage } from "next";
 
 import Layout from "../../../components/Layout/Layout";
+import type { StaticImageData } from "next/image";
 import Image from "next/image";
 import Link from "next/link";
 import Head from "next/head";
 import { useEffect } from "react";
 
+import pic1 from '../../../public/images/sponsors/pic1.png'
+import pic2 from '../../../public/images/sponsors/pic2.png'
+import pic3 from '../../../public/images/sponsors/pic3.png'
+import pic4 from '../../../public/images/sponsors/pic4.png'
+import pic5 from '../../../public/images/sponsors/pic5.png'
+
 interface Image {
   rotate: number;
-  src: string;
+  src: StaticImageData;
   alt: string;
 }
 
 const images: Image[] = [
   {
-    src: "/images/sponsors/pic1.png",
+    src: pic1,
     alt: "Audience watching a presentation",
     rotate: 6.56,
   },
   {
-    src: "/images/sponsors/pic2.png",
+    src: pic2,
     alt: "Audience watching a presentation with the name 'Codú' on the screen",
     rotate: -3.57,
   },
   {
-    src: "/images/sponsors/pic3.png",
+    src: pic3,
     alt: "Six people from Codú smiling at the camera",
     rotate: 4.58,
   },
   {
-    src: "/images/sponsors/pic4.png",
+    src: pic4,
     alt: "Audience watching a presentation",
     rotate: -4.35,
   },
   {
-    src: "/images/sponsors/pic5.png",
+    src: pic5,
     alt: "Audience smiling at the camera",
     rotate: 6.56,
   },
@@ -74,7 +81,7 @@ const Sponsorship: NextPage = () => {
           <section className="flex items-center relative bottom-12 justify-center overflow-hidden gap-8 sm:gap-20 sm:bottom-20 md:bottom-24  md:gap-36 lg:gap-44">
             {images.map((image) => (
               <div
-                key={image.src}
+                key={image.alt}
                 className={`w-32`}
                 style={{
                   transform: `rotate(calc(min(var(--scroll), 200) / 200 * ${image.rotate}deg))`
@@ -83,8 +90,6 @@ const Sponsorship: NextPage = () => {
                 <Image
                   src={image.src}
                   alt={image.alt}
-                  width={250}
-                  height={250}
                   className="max-w-[150px] sm:max-w-[200px] md:max-w-none"
                 />
               </div>

--- a/pages/notifications/index.tsx
+++ b/pages/notifications/index.tsx
@@ -13,7 +13,7 @@ import PageHeading from "../../components/PageHeading/PageHeading";
 import { trpc } from "../../utils/trpc";
 import { authOptions } from "../api/auth/[...nextauth]";
 import { unstable_getServerSession } from "next-auth";
-import { GetServerSideProps } from "next/types";
+import type { GetServerSideProps } from "next/types";
 
 const Notifications = () => {
   const {
@@ -89,7 +89,7 @@ const Notifications = () => {
       </Head>
       <Layout>
         <div className="relative sm:mx-auto max-w-2xl mx-4">
-          <div className="relative">
+          <div className="relative mb-4">
             <PageHeading>Notifications</PageHeading>
             {!!count && count > 0 && (
               <button


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

## Pull Request details:

- Resolve #285:
  - Use CSS variable and `calc` function to rotate images instead of using inline style and React state.
  - Statically import images instead of loading from `public` directory to take advantage of Next's automatic image optimization.
  - Other: fix typo on sponsorship page: `mounth` -> `month`
- Resolve #310: See screenshots below

## Any Breaking changes:

None

## Associated Screenshots:
    
**Before**
<img width="1376" alt="Screenshot 2023-06-28 at 7 22 04 p m" src="https://github.com/codu-code/codu/assets/28614996/1d687cc7-828d-4c48-a456-36ac75a2ff5f">

**After**
<img width="1373" alt="Screenshot 2023-06-28 at 7 22 21 p m" src="https://github.com/codu-code/codu/assets/28614996/7c65e2e5-aff6-46ee-9995-414f64eeced8">