### PR TITLE
Create Courses page

### DIFF
--- a/components/Course/CoursePreview.tsx
+++ b/components/Course/CoursePreview.tsx
@@ -1,0 +1,19 @@
+interface Props {
+  name: string;
+  description: string;
+  thumbnail: string;
+}
+
+const CoursePreview = ({ name, description, thumbnail }: Props) => {
+  return (
+    <div className="bg-neutral-800 flex">
+      <div className="">
+        <h2 className="font-bold text-lg px-6 py-1 border-neutral-500 border-b">{name}</h2>
+        <div className="px-6 py-3" dangerouslySetInnerHTML={{ __html: description }} />
+      </div>
+      <img alt={name} src={thumbnail} />
+    </div>
+  )
+}
+
+export default CoursePreview

--- a/components/Course/CoursePreview.tsx
+++ b/components/Course/CoursePreview.tsx
@@ -1,3 +1,5 @@
+import Image from "next/image";
+
 interface Props {
   name: string;
   description: string;
@@ -7,7 +9,13 @@ interface Props {
 const CoursePreview = ({ name, description, thumbnail }: Props) => {
   return (
     <div className="bg-neutral-800 flex flex-col md:flex-row">
-      <img alt={name} src={thumbnail} className="order-1 md:order-2" />
+      {/**
+       * `relative` and `overflow-hidden` are required for Image's `fill` to work
+       * @see https://nextjs.org/docs/pages/api-reference/components/image#fill
+       */}
+      <div className="order-1 md:order-2 relative overflow-hidden flex-shrink-0 aspect-video md:w-64 lg:w-96">
+        <Image alt={name} src={thumbnail} fill className="object-cover" />
+      </div>
       <div className="order-2 md:order-1">
         <h2 className="font-bold text-lg px-3 py-2 lg:px-6 lg:py-1 border-neutral-500 border-b">{name}</h2>
         <div className="px-3 py-3 lg:px-6" dangerouslySetInnerHTML={{ __html: description }} />

--- a/components/Course/CoursePreview.tsx
+++ b/components/Course/CoursePreview.tsx
@@ -6,12 +6,12 @@ interface Props {
 
 const CoursePreview = ({ name, description, thumbnail }: Props) => {
   return (
-    <div className="bg-neutral-800 flex">
-      <div className="">
-        <h2 className="font-bold text-lg px-6 py-1 border-neutral-500 border-b">{name}</h2>
-        <div className="px-6 py-3" dangerouslySetInnerHTML={{ __html: description }} />
+    <div className="bg-neutral-800 flex flex-col md:flex-row">
+      <img alt={name} src={thumbnail} className="order-1 md:order-2" />
+      <div className="order-2 md:order-1">
+        <h2 className="font-bold text-lg px-3 py-2 lg:px-6 lg:py-1 border-neutral-500 border-b">{name}</h2>
+        <div className="px-3 py-3 lg:px-6" dangerouslySetInnerHTML={{ __html: description }} />
       </div>
-      <img alt={name} src={thumbnail} />
     </div>
   )
 }

--- a/pages/alpha/courses/index.tsx
+++ b/pages/alpha/courses/index.tsx
@@ -1,0 +1,25 @@
+import type { NextPage } from "next";
+import Head from "next/head";
+import Layout from "../../../components/Layout/Layout";
+
+const Courses: NextPage = () => {
+  return (
+    <>
+      <Head>
+        <meta name="robots" content="noindex" />
+      </Head>
+
+      <Layout>
+        <div className="mx-2">
+          <div className="max-w-5xl sm:mx-auto mt-8 border-b pb-4 flex justify-between items-center lg:max-w-5xl sm:max-w-2xl">
+            <h1 className="text-3xl tracking-tight font-extrabold text-neutral-50 sm:text-4xl ">
+              Courses
+            </h1>
+          </div>
+        </div>
+      </Layout>
+    </>
+  );
+}
+
+export default Courses

--- a/pages/alpha/courses/index.tsx
+++ b/pages/alpha/courses/index.tsx
@@ -1,8 +1,21 @@
-import type { NextPage } from "next";
+import type { GetServerSideProps, InferGetServerSidePropsType, NextPage } from "next";
 import Head from "next/head";
 import Layout from "../../../components/Layout/Layout";
+import CoursePreview from "../../../components/Course/CoursePreview";
 
-const Courses: NextPage = () => {
+/**
+ * Feel free to update this interface when the Course model
+ * has been clearly defined in the Prisma schema.
+ */
+interface Course {
+  name: string;
+  description: string;
+  thumbnail: string;
+}
+
+const Courses: NextPage<
+  InferGetServerSidePropsType<typeof getServerSideProps>
+> = ({ courses }) => {
   return (
     <>
       <Head>
@@ -16,10 +29,33 @@ const Courses: NextPage = () => {
               Courses
             </h1>
           </div>
+
+          <div className="max-w-5xl sm:mx-auto lg:max-w-5xl mt-4">
+            {courses.map(({ name, description, thumbnail }) => (
+              <CoursePreview
+                key={name}
+                name={name}
+                description={description}
+                thumbnail={thumbnail}
+              />
+            ))}
+          </div>
         </div>
       </Layout>
     </>
   );
 }
+
+export const getServerSideProps: GetServerSideProps<{ courses: Course[] }> = async () => {
+  const courses: Course[] = [
+    {
+      name: 'Introduction to Web Development',
+      description: 'Discover the magic of web development in our beginner-friendly course! Master HTML for structure, CSS for style, and JavaScript for interactivity. Learn from experts, tackle hands-on projects, and build a strong foundation to create stunning, responsive websites. Unleash your creativity and join us today! <br /><br />Perfect for your first steps into a programming career or looking to refresh their fundamentals.',
+      thumbnail: 'https://via.placeholder.com/250',
+    }
+  ]
+
+  return { props: { courses } }
+};
 
 export default Courses

--- a/pages/alpha/courses/index.tsx
+++ b/pages/alpha/courses/index.tsx
@@ -30,7 +30,7 @@ const Courses: NextPage<
             </h1>
           </div>
 
-          <div className="max-w-5xl sm:mx-auto lg:max-w-5xl mt-4">
+          <div className="max-w-5xl sm:mx-auto lg:max-w-5xl sm:max-w-2xl mt-4">
             {courses.map(({ name, description, thumbnail }) => (
               <CoursePreview
                 key={name}

--- a/pages/alpha/courses/index.tsx
+++ b/pages/alpha/courses/index.tsx
@@ -51,7 +51,7 @@ export const getServerSideProps: GetServerSideProps<{ courses: Course[] }> = asy
     {
       name: 'Introduction to Web Development',
       description: 'Discover the magic of web development in our beginner-friendly course! Master HTML for structure, CSS for style, and JavaScript for interactivity. Learn from experts, tackle hands-on projects, and build a strong foundation to create stunning, responsive websites. Unleash your creativity and join us today! <br /><br />Perfect for your first steps into a programming career or looking to refresh their fundamentals.',
-      thumbnail: 'https://via.placeholder.com/250',
+      thumbnail: 'https://images.unsplash.com/photo-1612758272676-dec3a658080e?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1770&q=80',
     }
   ]
 


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

## Pull Request details:
- Resolve #333: Create a new Courses page following Figma design.

**Notes**:
- I am not sure why the Course Preview card on Figma is not spanning the full width of the layout. For now, I'm making its width 100%.
- Some arbitrary sizing rules of the thumbnail can be discussed:
  - On mobile, the width is 100% of the container, and the height is calculated so that the thumbnail will have the aspect ratio of 16 / 9.
  - On medium-sized screens, the width is fixed at 256px and the height depends on the height of the whole card.
  - On large-sized screens, the width is fixed at 384px and the height depends on the height of the whole card.

## Any Breaking changes:
None

## Associated Screenshots:
**Mobile**
<img width="302" alt="Screenshot 2023-07-03 at 12 09 10 a m" src="https://github.com/codu-code/codu/assets/28614996/163e3fd8-6c45-477f-bd18-828d43e92dbf">

**Medium screen**
<img width="461" alt="Screenshot 2023-07-03 at 12 09 41 a m" src="https://github.com/codu-code/codu/assets/28614996/986eb036-459b-444b-b4f9-9d4c223f6462">

**Large screen**
<img width="1368" alt="Screenshot 2023-07-03 at 12 10 20 a m" src="https://github.com/codu-code/codu/assets/28614996/2c2ab76e-338a-4bb8-8b31-ad6175fa764d">

