### PR TITLE
#344 Show copy code block icon only on hover

### DIFF
--- a/components/markdocNodes/Code/Code.tsx
+++ b/components/markdocNodes/Code/Code.tsx
@@ -179,6 +179,10 @@ export default function Code({ children, language }: Props) {
             background: rgb(243 244 246);
             padding: 2px 2px 0px 4px;
           }
+
+          pre {
+            text-wrap: wrap;
+          }
         `}
       </style>
     </div>

--- a/components/markdocNodes/Code/Code.tsx
+++ b/components/markdocNodes/Code/Code.tsx
@@ -166,14 +166,13 @@ export default function Code({ children, language }: Props) {
       <style jsx>
         {`
           .code {
-            position: relative;
+            display: grid;
+            grid-template-rows: 30px 1fr;
           }
           .code button {
-            appearance: none;
-            position: absolute;
+            justify-self: end;
+            margin-right: 11px;
             color: inherit;
-            top: ${lines.length === 1 ? "17px" : "13px"};
-            right: 11px;
             border-radius: 4px;
             border: none;
             font-size: 15px;

--- a/components/markdocNodes/Code/Code.tsx
+++ b/components/markdocNodes/Code/Code.tsx
@@ -205,7 +205,7 @@ export default function Code({ children, language }: Props) {
 
           @media (prefers-color-scheme: light) {
             .code button {
-              background-color: #000000;
+              background-color: #040404;
             }
 
             .code button:hover,

--- a/components/markdocNodes/Code/Code.tsx
+++ b/components/markdocNodes/Code/Code.tsx
@@ -156,12 +156,13 @@ export default function Code({ children, language }: Props) {
 
   return (
     <div className="code" aria-live="polite">
-      <pre key={children} ref={ref} className={`language-${lang}`}>
-        {children}
-      </pre>
       <button type="button" onClick={() => setCopied(true)}>
         <Icon icon={copied ? "copied" : "copy"} color="#fb923c" />
       </button>
+      <pre key={children} ref={ref} className={`language-${lang}`}>
+        {children}
+      </pre>
+
       <style jsx>
         {`
           .code {

--- a/components/markdocNodes/Code/Code.tsx
+++ b/components/markdocNodes/Code/Code.tsx
@@ -151,9 +151,6 @@ export default function Code({ children, language }: Props) {
 
   const lang = language === "md" ? "markdoc" : language || "markdoc";
 
-  const lines =
-    typeof children === "string" ? children.split("\n").filter(Boolean) : [];
-
   return (
     <div className="code" aria-live="polite" tabIndex={0}>
       <button type="button" onClick={() => setCopied(true)}>

--- a/components/markdocNodes/Code/Code.tsx
+++ b/components/markdocNodes/Code/Code.tsx
@@ -155,11 +155,11 @@ export default function Code({ children, language }: Props) {
     typeof children === "string" ? children.split("\n").filter(Boolean) : [];
 
   return (
-    <div className="code" aria-live="polite">
+    <div className="code" aria-live="polite" tabIndex={0}>
       <button type="button" onClick={() => setCopied(true)}>
         <Icon icon={copied ? "copied" : "copy"} color="#fb923c" />
       </button>
-      <pre key={children} ref={ref} className={`language-${lang}`}>
+      <pre key={children} ref={ref} className={`language-${lang}`} tabIndex={0}>
         {children}
       </pre>
 

--- a/components/markdocNodes/Code/Code.tsx
+++ b/components/markdocNodes/Code/Code.tsx
@@ -165,7 +165,7 @@ export default function Code({ children, language }: Props) {
           .code {
             border-radius: 4px;
             display: grid;
-            gap: 1em;
+            gap: 5px;
             grid-template-rows: 30px 1fr;
           }
           .code button {
@@ -193,7 +193,7 @@ export default function Code({ children, language }: Props) {
 
           pre {
             margin: 0;
-            padding: 1em;
+            padding: 0.5em 1em;
             text-wrap: wrap;
           }
 

--- a/components/markdocNodes/Code/Code.tsx
+++ b/components/markdocNodes/Code/Code.tsx
@@ -176,7 +176,7 @@ export default function Code({ children, language }: Props) {
             border-radius: 4px;
             border: none;
             font-size: 15px;
-            background: rgb(243 244 246);
+            background-color: rgb(243 244 246);
             padding: 2px 2px 0px 4px;
             transform: scaleY(0);
             transition: transform 500ms ease-in-out;
@@ -210,15 +210,13 @@ export default function Code({ children, language }: Props) {
 
             .code button:hover,
             .code button:focus {
-              background-color: #ffffff;
-              outline: 2px solid #000000;
-              outline-style: inset;
+              background-color: #d1d5db;
               transition: background-color 250ms ease-in-out;
             }
 
             .code,
             .code pre {
-              background-color: #ffffff;
+              background-color: #d1d5db;
             }
           }
         `}

--- a/components/markdocNodes/Code/Code.tsx
+++ b/components/markdocNodes/Code/Code.tsx
@@ -202,6 +202,25 @@ export default function Code({ children, language }: Props) {
               transform: scaleY(1);
             }
           }
+
+          @media (prefers-color-scheme: light) {
+            .code button {
+              background-color: #000000;
+            }
+
+            .code button:hover,
+            .code button:focus {
+              background-color: #ffffff;
+              outline: 2px solid #000000;
+              outline-style: inset;
+              transition: background-color 250ms ease-in-out;
+            }
+
+            .code,
+            .code pre {
+              background-color: #ffffff;
+            }
+          }
         `}
       </style>
     </div>

--- a/components/markdocNodes/Code/Code.tsx
+++ b/components/markdocNodes/Code/Code.tsx
@@ -185,7 +185,7 @@ export default function Code({ children, language }: Props) {
 
           .code button:focus,
           .code:hover > button,
-          .code:focus-visible > button {
+          .code:focus-within > button {
             transform: scaleY(1);
             transition: transform 500ms ease-in-out;
             transform-origin: top;

--- a/components/markdocNodes/Code/Code.tsx
+++ b/components/markdocNodes/Code/Code.tsx
@@ -163,10 +163,13 @@ export default function Code({ children, language }: Props) {
       <style jsx>
         {`
           .code {
+            border-radius: 4px;
             display: grid;
+            gap: 1em;
             grid-template-rows: 30px 1fr;
           }
           .code button {
+            margin-top: 5px;
             justify-self: end;
             margin-right: 11px;
             color: inherit;
@@ -189,7 +192,15 @@ export default function Code({ children, language }: Props) {
           }
 
           pre {
+            margin: 0;
+            padding: 1em;
             text-wrap: wrap;
+          }
+
+          @media (max-width: 1024px) {
+            .code button {
+              transform: scaleY(1);
+            }
           }
         `}
       </style>

--- a/components/markdocNodes/Code/Code.tsx
+++ b/components/markdocNodes/Code/Code.tsx
@@ -178,6 +178,17 @@ export default function Code({ children, language }: Props) {
             font-size: 15px;
             background: rgb(243 244 246);
             padding: 2px 2px 0px 4px;
+            transform: scaleY(0);
+            transition: transform 500ms ease-in-out;
+            transform-origin: bottom;
+          }
+
+          .code button:focus,
+          .code:hover > button,
+          .code:focus-visible > button {
+            transform: scaleY(1);
+            transition: transform 500ms ease-in-out;
+            transform-origin: top;
           }
 
           pre {

--- a/components/markdocNodes/Code/Code.tsx
+++ b/components/markdocNodes/Code/Code.tsx
@@ -167,6 +167,7 @@ export default function Code({ children, language }: Props) {
             display: grid;
             gap: 5px;
             grid-template-rows: 30px 1fr;
+            background-color: #1c1b1b;
           }
           .code button {
             margin-top: 5px;
@@ -195,6 +196,7 @@ export default function Code({ children, language }: Props) {
             margin: 0;
             padding: 0.5em 1em;
             text-wrap: wrap;
+            background-color: inherit;
           }
 
           @media (max-width: 1024px) {
@@ -205,7 +207,7 @@ export default function Code({ children, language }: Props) {
 
           @media (prefers-color-scheme: light) {
             .code button {
-              background-color: #040404;
+              background-color: #020202;
             }
 
             .code button:hover,

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -12,18 +12,18 @@ body {
 @tailwind utilities;
 
 @layer base {
-  [type='text'],
-  [type='email'],
-  [type='url'],
-  [type='password'],
-  [type='number'],
-  [type='date'],
-  [type='datetime-local'],
-  [type='month'],
-  [type='search'],
-  [type='tel'],
-  [type='time'],
-  [type='week'],
+  [type="text"],
+  [type="email"],
+  [type="url"],
+  [type="password"],
+  [type="number"],
+  [type="date"],
+  [type="datetime-local"],
+  [type="month"],
+  [type="search"],
+  [type="tel"],
+  [type="time"],
+  [type="week"],
   [multiple],
   textarea,
   select {
@@ -45,7 +45,6 @@ body {
 
 .fancy-link {
   @apply bg-clip-text text-transparent bg-gradient-to-r from-orange-400 to-pink-600 tracking-wide cursor-pointer;
-  
 }
 
 .fancy-link:hover {
@@ -82,7 +81,7 @@ body {
   @apply visible;
 }
 
-.prose pre {
+.prose .code {
   @apply border border-neutral-200 bg-neutral-100 dark:border-neutral-700 dark:bg-black;
 }
 
@@ -231,60 +230,59 @@ table {
   margin: 0 !important;
 }
 
-
 .slateP > p {
-  margin: 0!important;
+  margin: 0 !important;
 }
 
 /* Loading animation */
 .loader-dots div {
-    animation-timing-function: cubic-bezier(0, 1, 1, 0);
+  animation-timing-function: cubic-bezier(0, 1, 1, 0);
 }
 .loader-dots div:nth-child(1) {
-    left: 8px;
-    animation: loader-dots1 0.6s infinite;
+  left: 8px;
+  animation: loader-dots1 0.6s infinite;
 }
 .loader-dots div:nth-child(2) {
-    left: 8px;
-    animation: loader-dots2 0.6s infinite;
+  left: 8px;
+  animation: loader-dots2 0.6s infinite;
 }
 .loader-dots div:nth-child(3) {
-    left: 32px;
-    animation: loader-dots2 0.6s infinite;
+  left: 32px;
+  animation: loader-dots2 0.6s infinite;
 }
 .loader-dots div:nth-child(4) {
-    left: 56px;
-    animation: loader-dots3 0.6s infinite;
+  left: 56px;
+  animation: loader-dots3 0.6s infinite;
 }
-
 
 /* plate editor style overrides  */
 /* TODO: we should set what styles we can in the components directly */
 
 input[placeholder="Paste link"] {
-    color: black;
+  color: black;
 }
 
 input[placeholder="Text to display"] {
-    color: black;
+  color: black;
 }
 
-.slate-kbd, .slate-code_line {
-  color: black
+.slate-kbd,
+.slate-code_line {
+  color: black;
 }
 
-[class^="PlateFloatingLink"], [class^="PlateFloatingMedia"] {
-    color: black;
+[class^="PlateFloatingLink"],
+[class^="PlateFloatingMedia"] {
+  color: black;
 }
 
 [data-testid="CodeBlockSelectElement"] {
-    position: absolute;
+  position: absolute;
   right: 10px;
   width: 20px;
 }
 
 [data-slate-editor="true"] {
-  
 }
 
 .slate-code_block {
@@ -292,7 +290,7 @@ input[placeholder="Text to display"] {
 }
 
 .slate-code_block select {
- position: absolute;
+  position: absolute;
   right: 10px;
   width: 25%;
 }
@@ -309,46 +307,52 @@ input[placeholder="Text to display"] {
   list-style-type: decimal;
 }
 
-.slate-MediaEmbedElement-handleRight, .slate-MediaEmbedElement-handleLeft, .slate-MediaEmbedElement-caption {
-  display: none!important;
+.slate-MediaEmbedElement-handleRight,
+.slate-MediaEmbedElement-handleLeft,
+.slate-MediaEmbedElement-caption {
+  display: none !important;
 }
 
 .jsCcLr {
-  padding-bottom: 10px!important;
+  padding-bottom: 10px !important;
 }
 
-.slate-a, .slateP a {
-  color: #1E90FF!important;
-  text-decoration: none!important;
+.slate-a,
+.slateP a {
+  color: #1e90ff !important;
+  text-decoration: none !important;
   cursor: pointer;
 }
 
-.slate-a:hover, .slateP a:hover {
-  color: #87CEEB!important;
-  text-decoration: none!important;
-
+.slate-a:hover,
+.slateP a:hover {
+  color: #87ceeb !important;
+  text-decoration: none !important;
 }
 
-.slate-blockquote, blockquote {
+.slate-blockquote,
+blockquote {
   font-style: italic;
-  color: #f3f4f6!important;
-  border-left-width: 0.25rem!important;
-  padding-left: 1em!important;
-  border-color: #f3f4f6!important;
+  color: #f3f4f6 !important;
+  border-left-width: 0.25rem !important;
+  padding-left: 1em !important;
+  border-color: #f3f4f6 !important;
 }
 
 .slate-ImageElement-caption {
-  color: #9ca3af!important;
-  font-size: 0.8em!important;
+  color: #9ca3af !important;
+  font-size: 0.8em !important;
 }
 
-.slateP li, .slateP ol, .slateP ul {
-  margin-top: 0!important;
-  margin-bottom: 0!important;
+.slateP li,
+.slateP ol,
+.slateP ul {
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
 }
 
 .slate-li {
-  color: #d1d5db!important;
+  color: #d1d5db !important;
   padding-left: 0.4em;
   line-height: 1.2em;
 }
@@ -359,32 +363,27 @@ input[placeholder="Text to display"] {
 
 /* end of plate editor styles  */
 
-
 @keyframes loader-dots1 {
-    0% {
-        transform: scale(0);
-    }
-    100% {
-        transform: scale(1);
-    }
+  0% {
+    transform: scale(0);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 @keyframes loader-dots3 {
-    0% {
-        transform: scale(1);
-    }
-    100% {
-        transform: scale(0);
-    }
+  0% {
+    transform: scale(1);
+  }
+  100% {
+    transform: scale(0);
+  }
 }
 @keyframes loader-dots2 {
-    0% {
-        transform: translate(0, 0);
-    }
-    100% {
-        transform: translate(24px, 0);
-    }
+  0% {
+    transform: translate(0, 0);
+  }
+  100% {
+    transform: translate(24px, 0);
+  }
 }
-
-
-
-


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

## Pull Request details:
- Code block converted to grid to allow control of copy button (and code excerpt if needed)
- Text-wrap set for code text responsiveness.
- globals.css updated so the border goes around the code div (now grid parent) and not pre (code excerpt).
Note: I believe prettier updated quite a bit in the global.css see lines 84 / 85 for updates.
`.prose pre {
.prose .code {
  @apply border border-neutral-200 bg-neutral-100 dark:border-neutral-700 dark:bg-black;
}`
- Transform Scale Y used to "hide" the button as this is not resource intensive.
- Media query for copy button so that it  always visible on devices less than 1024px per the below docs. https://tailwindcss.com/docs/screens
- For devices bigger than 1024px hover and focus states added 
- A transition for the transform scale y has been added to grab users attention of the copy button (both hover and focus states).
- Tab index added to code & pre to allow users to skip to code sections / maneuver better using tab key.
- Button code has been moved up in the code div so that the DOM order is correct for screen-readers as this function is vitally important to the blog posts.
- General margin and padding updated for pre.



## Any Breaking changes:
None

## Associated Screenshots:

Text-Wrap
![text wrap in code block](https://github.com/codu-code/codu/assets/130906067/06c0d821-6bcb-4da2-ab04-6ec5f55a7b06)

Copy button visible on mobile devices
![code block mobile devices](https://github.com/codu-code/codu/assets/130906067/6d568b01-cf6e-4e66-8882-2ddc22fad138)

Focus and hover states for desktop:
![hover focus code block](https://github.com/codu-code/codu/assets/130906067/38106ee8-f0f9-429a-bbb4-bbc79844a832)

