### PR TITLE
Fix bug #416 Random bookmarks

### DIFF
--- a/server/trpc/router/post.ts
+++ b/server/trpc/router/post.ts
@@ -309,7 +309,8 @@ export const postRouter = router({
     });
 
     const cleaned = response.map((post) => {
-      const currentUserLikesPost = !!post.bookmarks.length;
+      let currentUserLikesPost = !!post.bookmarks.length;
+      if (userId === undefined) currentUserLikesPost = false;
       post.bookmarks = [];
       return { ...post, currentUserLikesPost };
     });
@@ -354,7 +355,8 @@ export const postRouter = router({
     });
 
     const cleaned = response.map((post) => {
-      const currentUserLikesPost = !!post.bookmarks.length;
+      let currentUserLikesPost = !!post.bookmarks.length;
+      if (userId === undefined) currentUserLikesPost = false;
       post.bookmarks = [];
       return { ...post, currentUserLikesPost };
     });


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

👉 _**Please remove the below and replace with your own values, leaving the headers where they are.**_ 👈

## Pull Request details:
What is happening is that any article that is liked by any logged in user, has the users id added to the Bookmarks array, which is a property of the Post object. When prisma queries the DB, it selects the userId from Bookmarks where userId. This seems to work fine when the user is logged in. However when userId is undefined it returns all the userId. Fixed by checking if user is undefined when assigning the currentUserLikesPost variable.

## Any Breaking changes:
None

## Associated Screenshots:
None    

Closes #416 
