### PR TITLE
Updated icon color

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -198,7 +198,7 @@ const Home: NextPage = () => {
                           strokeLinejoin="round"
                           d="M19.5 5.25l-7.5 7.5-7.5-7.5m15 6l-7.5 7.5-7.5-7.5"
                         />
-                      </svg>                      
+                      </svg>
                     </button>
                   </div>
                 </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -190,15 +190,15 @@ const Home: NextPage = () => {
                         fill="none"
                         viewBox="0 0 24 24"
                         strokeWidth={1.5}
-                        stroke="ffffff" // Change "currentColor" to "#ffffff"
+                        stroke="#ffffff" // Change "currentColor" to "#ffffff"
                         className="w-8 h-8"
                       >
                         <path
                           strokeLinecap="round"
                           strokeLinejoin="round"
-                          d="M19.5 5.25l-7.5 7.5-7.5-7.5m15 6l-7.5 7.5-7.5-7.5"
+                          d="M19.5 5.25l-7.5 7.5-7.5-7.5"
                         />
-                      </svg>
+                    </svg>
                     </button>
                   </div>
                 </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -190,7 +190,7 @@ const Home: NextPage = () => {
                         fill="none"
                         viewBox="0 0 24 24"
                         strokeWidth={1.5}
-                        stroke="ffffff"
+                        stroke="#ffffff"
                         className="w-8 h-8"
                       >
                         <path

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -190,15 +190,15 @@ const Home: NextPage = () => {
                         fill="none"
                         viewBox="0 0 24 24"
                         strokeWidth={1.5}
-                        stroke="#ffffff" // Change "currentColor" to "#ffffff"
+                        stroke="ffffff"
                         className="w-8 h-8"
                       >
                         <path
                           strokeLinecap="round"
                           strokeLinejoin="round"
-                          d="M19.5 5.25l-7.5 7.5-7.5-7.5"
+                          d="M19.5 5.25l-7.5 7.5-7.5-7.5m15 6l-7.5 7.5-7.5-7.5"
                         />
-                    </svg>
+                      </svg>                      
                     </button>
                   </div>
                 </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -190,7 +190,7 @@ const Home: NextPage = () => {
                         fill="none"
                         viewBox="0 0 24 24"
                         strokeWidth={1.5}
-                        stroke="currentColor"
+                        stroke="ffffff" // Change "currentColor" to "#ffffff"
                         className="w-8 h-8"
                       >
                         <path


### PR DESCRIPTION
In this updated code, I replaced stroke="currentColor" with stroke="#ffffff". This modification explicitly sets the stroke color to white (#ffffff) for the SVG, ensuring that the stroke is consistently displayed in white regardless of the surrounding text color defined by CSS.

<svg
  xmlns="http://www.w3.org/2000/svg"
  fill="none"
  viewBox="0 0 24 24"
  strokeWidth={1.5}
  **stroke="#ffffff" <!-- Updated stroke color to white -->**
  className="w-8 h-8"
>
  <path
    strokeLinecap="round"
    strokeLinejoin="round"
    d="M19.5 5.25l-7.5 7.5-7.5-7.5"
  />
</svg>
