### PR TITLE
Added light/dark mode support for my-post page

### DIFF
--- a/pages/my-posts/index.tsx
+++ b/pages/my-posts/index.tsx
@@ -128,7 +128,7 @@ const MyPosts: NextPage = ({
             </button>
           </div>
         </Modal>
-        <div className="relative sm:mx-auto max-w-2xl mx-4">
+        <div className="relative sm:mx-auto max-w-2xl mx-4 bg-neutral-100 dark:bg-black">
           <div className="border-b border-neutral-200 mt-8 mb-4">
             <div className="sm:hidden">
               <label htmlFor="tabs" className="sr-only">
@@ -158,8 +158,8 @@ const MyPosts: NextPage = ({
                   <Link
                     className={classNames(
                       tab.current
-                        ? "bg-neutral-100 text-neutral-700"
-                        : "text-neutral-200 hover:text-neutral-400",
+                        ? "bg-black dark:bg-neutral-100 text-neutral-200 dark:text-neutral-700"
+                        : "text-neutral-700 dark:text-neutral-200 hover:text-neutral-400",
                       "px-4 py-2 font-medium text-base rounded-t-md",
                     )}
                     aria-current={tab.current ? "page" : undefined}
@@ -186,7 +186,10 @@ const MyPosts: NextPage = ({
             {selectedTabData.status === "success" &&
               selectedTabData.data?.map(
                 ({ id, title, excerpt, readTimeMins, slug }) => (
-                  <article className="border-2 p-4 mb-4 bg-black" key={id}>
+                  <article
+                    className="border-2 p-4 mb-4 bg-white dark:bg-black border-neutral-100"
+                    key={id}
+                  >
                     {tab === "published" ? (
                       <Link href={`articles/${slug}`}>
                         <h2 className="text-2xl font-semibold mb-2 hover:underline">


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

## Pull Request details:
- Added light/dark mode support for my-post page
- Fix for #493 

## Any Breaking changes:
- None

## Associated Screenshots:
    
- my-posts without any articles (light/dark mode)
<img width="1728" alt="Screenshot 2023-10-11 at 16 40 43" src="https://github.com/codu-code/codu/assets/30935658/e9345227-1884-4095-8e70-9214d21c9d86">
<img width="1728" alt="Screenshot 2023-10-11 at 16 40 27" src="https://github.com/codu-code/codu/assets/30935658/30fd1896-31e8-4e27-bd82-e7c911542516">

- my-posts with articles in draft stage (light/dark mode)
<img width="1728" alt="Screenshot 2023-10-11 at 16 46 11" src="https://github.com/codu-code/codu/assets/30935658/bd1c5276-74ee-4f68-8be8-49f7fe1757cc">
<img width="1728" alt="Screenshot 2023-10-11 at 16 46 03" src="https://github.com/codu-code/codu/assets/30935658/7ad1c50e-9c23-4bcd-8e9c-a0fc44880292">

- my-posts with articles in published stage (light/dark mode)
<img width="1728" alt="Screenshot 2023-10-11 at 16 44 34" src="https://github.com/codu-code/codu/assets/30935658/a905403d-8862-461a-9acb-14c5d70c33d2">
<img width="1728" alt="Screenshot 2023-10-11 at 16 44 24" src="https://github.com/codu-code/codu/assets/30935658/e762922f-dfa3-446b-b263-640b314fcba9">

