### PR TITLE
add default color to sun icon

### DIFF
--- a/components/Theme/ThemeToggle.tsx
+++ b/components/Theme/ThemeToggle.tsx
@@ -14,7 +14,7 @@ const ThemeToggle = () => {
       className="relative flex justify-center items-center text-neutral-900 dark:text-neutral-300 hover:dark:text-white hover:text-yellow-500 focus:text-neutral-300 focus:outline-none focus:ring-2 focus:ring-rose-500 focus:ring-offset-2 ml-3 rounded-full"
     >
       <Menu.Button className="relative h-full">
-        <SunIcon className="w-6 h-6 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+        <SunIcon className="w-6 h-6 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0 text-neutral-400" />
         <MoonIcon className="absolute top-0 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
         <span className="sr-only">Toggle theme</span>
       </Menu.Button>


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)


## Pull Request details:
- Simple fix: added `text-neutral-400` to the theme toggle's sun icon to add a default color of `neutral-400`.
- Fixes #517 

## Any Breaking changes:
None

## Associated Screenshots:
![ss](https://github.com/codu-code/codu/assets/56351143/fee88c2b-324a-46bf-9d82-b8f20c7dcdd6)
![ss-2](https://github.com/codu-code/codu/assets/56351143/9ef675ff-80ed-4d2e-b25e-8bc2464366a1)


