### PR TITLE
Remove 'dark:focus:bg-slate-700' on each menu item

### DIFF
--- a/components/Theme/ThemeToggle.tsx
+++ b/components/Theme/ThemeToggle.tsx
@@ -30,7 +30,7 @@ const ThemeToggle = () => {
         <Menu.Items className="origin-top-right top-7 absolute right-0 mt-2 w-48 rounded-md shadow-lg py-1 bg-white ring-1 px-1 ring-black ring-opacity-5 focus:outline-none">
           <Menu.Item
             as="button"
-            className="relative flex cursor-default text-base md:text-sm select-none items-center rounded-sm font-medium outline-none hover:hover:bg-neutral-200   focus:hover:bg-neutral-200  data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-slate-700 text-black w-full px-4 py-2"
+            className="relative flex cursor-default text-base md:text-sm select-none items-center rounded-sm font-medium outline-none hover:hover:bg-neutral-200   focus:hover:bg-neutral-200  data-[disabled]:pointer-events-none data-[disabled]:opacity-50 text-black w-full px-4 py-2"
             onClick={() => setTheme("light")}
           >
             <SunIcon className="mr-2 h-4 w-4" />
@@ -38,7 +38,7 @@ const ThemeToggle = () => {
           </Menu.Item>
           <Menu.Item
             as="button"
-            className="relative flex cursor-default text-base md:text-sm select-none items-center rounded-sm px-4 py-2 font-medium outline-none w-full hover:hover:bg-neutral-200   focus:hover:bg-neutral-200  data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-slate-700 text-black"
+            className="relative flex cursor-default text-base md:text-sm select-none items-center rounded-sm px-4 py-2 font-medium outline-none w-full hover:hover:bg-neutral-200   focus:hover:bg-neutral-200  data-[disabled]:pointer-events-none data-[disabled]:opacity-50 text-black"
             onClick={() => setTheme("dark")}
           >
             <MoonIcon className="mr-2 h-4 w-4" />


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

👉 _**Please remove the below and replace with your own values, leaving the headers where they are.**_ 👈

## Pull Request details:
- Removed `CSS: dark:focus:bg-slate-700` on each `Menu Item` to have the same styles as the `light mode`

## Any Breaking changes:
- None

## Associated Screenshots:
    
![theme](https://github.com/codu-code/codu/assets/88434287/6d773d8e-d799-412d-b62f-865643dec92c)
