### PR TITLE
Matching padding in both notification and theme icon, fix focus state…

### DIFF
--- a/components/Nav/Nav.tsx
+++ b/components/Nav/Nav.tsx
@@ -135,7 +135,7 @@ const Nav = ({ session }: { session: Session | null }) => {
                       <Link
                         title="Notifications"
                         href="/notifications"
-                        className="relative ml-3 flex-shrink-0 rounded-full p-1 text-neutral-400 hover:text-neutral-300 focus:outline-none focus:ring-2 focus:ring-rose-500 focus:ring-offset-2"
+                        className="relative ml-3 flex-shrink-0 rounded-full  text-neutral-400 hover:text-neutral-300 focus:outline-none focus:ring-2 focus:ring-rose-500 focus:ring-offset-2"
                       >
                         <span className="sr-only">View notifications</span>
                         {hasNotifications && (

--- a/components/Theme/ThemeToggle.tsx
+++ b/components/Theme/ThemeToggle.tsx
@@ -1,7 +1,7 @@
-import { Fragment } from "react";
 import { Menu, Transition } from "@headlessui/react";
-import { SunIcon, MoonIcon, DesktopComputerIcon } from "@heroicons/react/solid";
+import { MoonIcon, SunIcon } from "@heroicons/react/solid";
 import { useTheme } from "next-themes";
+import { Fragment } from "react";
 
 // FUTURE CSS FIX - Menu - inline block, top alignment - customisable css classname prop.
 
@@ -11,41 +11,50 @@ const ThemeToggle = () => {
   return (
     <Menu
       as="div"
-      className="relative flex justify-center items-center dark:text-neutral-300 hover:dark:text-white hover:text-yellow-500 focus:text-neutral-300 focus:outline-none text-neutral-400 focus:ring-2 focus:ring-rose-500 focus:ring-offset-2 ml-3 rounded-full"
+      className="relative flex justify-center items-center text-neutral-900 dark:text-neutral-400 hover:dark:text-neutral-300 hover:text-yellow-500 focus:text-neutral-300 focus:outline-none focus:ring-2 focus:ring-rose-500 focus:ring-offset-2 ml-3 rounded-full"
     >
-      <Menu.Button className="relative h-full">
-        <SunIcon className="w-6 h-6 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-        <MoonIcon className="absolute top-0 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-        <span className="sr-only">Toggle theme</span>
-      </Menu.Button>
-      <Transition
-        as={Fragment}
-        enter="transition ease-out duration-100"
-        enterFrom="transform opacity-0 scale-95"
-        enterTo="transform opacity-100 scale-100"
-        leave="transition ease-in duration-75"
-        leaveFrom="transform opacity-100 scale-100"
-        leaveTo="transform opacity-0 scale-95"
-      >
-        <Menu.Items className="origin-top-right top-7 absolute right-0 mt-2 w-48 rounded-md shadow-lg py-1 bg-white ring-1 px-1 ring-black ring-opacity-5 focus:outline-none">
-          <Menu.Item
-            as="button"
-            className="relative flex cursor-default text-base md:text-sm select-none items-center rounded-sm font-medium outline-none hover:hover:bg-neutral-200   focus:hover:bg-neutral-200  data-[disabled]:pointer-events-none data-[disabled]:opacity-50 text-black w-full px-4 py-2"
-            onClick={() => setTheme("light")}
+      {({ open }) => (
+        <>
+          <Menu.Button
+            className={`relative h-full ${
+              open &&
+              "outline-none ring-2 ring-rose-500 ring-offset-2 rounded-full"
+            }`}
           >
-            <SunIcon className="mr-2 h-4 w-4" />
-            <span>Light</span>
-          </Menu.Item>
-          <Menu.Item
-            as="button"
-            className="relative flex cursor-default text-base md:text-sm select-none items-center rounded-sm px-4 py-2 font-medium outline-none w-full hover:hover:bg-neutral-200   focus:hover:bg-neutral-200  data-[disabled]:pointer-events-none data-[disabled]:opacity-50 text-black"
-            onClick={() => setTheme("dark")}
+            <SunIcon className="w-6 h-6 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0 text-neutral-400" />
+            <MoonIcon className="w-6 h-6 absolute top-0 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+            <span className="sr-only">Toggle theme</span>
+          </Menu.Button>
+          <Transition
+            as={Fragment}
+            enter="transition ease-out duration-100"
+            enterFrom="transform opacity-0 scale-95"
+            enterTo="transform opacity-100 scale-100"
+            leave="transition ease-in duration-75"
+            leaveFrom="transform opacity-100 scale-100"
+            leaveTo="transform opacity-0 scale-95"
           >
-            <MoonIcon className="mr-2 h-4 w-4" />
-            <span>Dark</span>
-          </Menu.Item>
-        </Menu.Items>
-      </Transition>
+            <Menu.Items className="origin-top-right top-7 absolute right-0 mt-2 w-48 rounded-md shadow-lg py-1 bg-white ring-1 px-1 ring-black ring-opacity-5 focus:outline-none">
+              <Menu.Item
+                as="button"
+                className="relative flex cursor-default text-base md:text-sm select-none items-center rounded-sm font-medium outline-none hover:hover:bg-neutral-200   focus:hover:bg-neutral-200  data-[disabled]:pointer-events-none data-[disabled]:opacity-50 text-black w-full px-4 py-2"
+                onClick={() => setTheme("light")}
+              >
+                <SunIcon className="mr-2 h-4 w-4" />
+                <span>Light</span>
+              </Menu.Item>
+              <Menu.Item
+                as="button"
+                className="relative flex cursor-default text-base md:text-sm select-none items-center rounded-sm px-4 py-2 font-medium outline-none w-full hover:hover:bg-neutral-200   focus:hover:bg-neutral-200  data-[disabled]:pointer-events-none data-[disabled]:opacity-50 text-black"
+                onClick={() => setTheme("dark")}
+              >
+                <MoonIcon className="mr-2 h-4 w-4" />
+                <span>Dark</span>
+              </Menu.Item>
+            </Menu.Items>
+          </Transition>
+        </>
+      )}
     </Menu>
   );
 };


### PR DESCRIPTION
… to match notifications button

# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

👉 _**Please remove the below and replace with your own values, leaving the headers where they are.**_ 👈

## Pull Request details:
- Reduce button padding in the notifications button to match the theme button. 
- Focus state for the theme button to match the notifications button. 
- Change the shade of the theme button to match the notification button
- Change the hovering shade of the theme button to match the notification button. 

## Any Breaking changes:
- No breaking changes 
<img width="99" alt="Screenshot 2023-10-14 at 20 16 08" src="https://github.com/codu-code/codu/assets/58437550/86b8b664-a04d-4a5e-a63d-1d5469741290">
<img width="205" alt="Screenshot 2023-10-14 at 20 17 24" src="https://github.com/codu-code/codu/assets/58437550/7ca7fadf-6fd1-4dd5-b77f-b861df3669dc">

## Associated Screenshots:
    
