### PR TITLE
Add check for session in bellicon in mobile view

### DIFF
--- a/components/Nav/Nav.tsx
+++ b/components/Nav/Nav.tsx
@@ -203,17 +203,20 @@ const Nav = ({ session }: { session: Session | null }) => {
               </div>
               <div className="-mr-2 flex items-center md:hidden">
                 <ThemeToggle />
-                <Link
-                  title="Notifications"
-                  href="/notifications"
-                  className="relative group block mobile-nav-button"
-                >
-                  <span className="sr-only">View notifications</span>
-                  {hasNotifications && (
-                    <div className="absolute animate-pulse rounded-full h-2 w-2 bg-pink-500 right-1 top-1" />
-                  )}
-                  <BellIcon className="h-6 w-6" aria-hidden="true" />
-                </Link>
+
+                {session && (
+                  <Link
+                    title="Notifications"
+                    href="/notifications"
+                    className="relative group block mobile-nav-button"
+                  >
+                    <span className="sr-only">View notifications</span>
+                    {hasNotifications && (
+                      <div className="absolute animate-pulse rounded-full h-2 w-2 bg-pink-500 right-1 top-1" />
+                    )}
+                    <BellIcon className="h-6 w-6" aria-hidden="true" />
+                  </Link>
+                )}
                 {/* Mobile menu button */}
                 <Disclosure.Button className="group mobile-nav-button">
                   <span className="sr-only">Open main menu</span>


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

## Pull Request details:
- Bug fix: When in mobile view the bell icon was showing. 
- To fix it I added a wrapper with a check for session around, following the desktop view. 

## Any Breaking changes:
- None
## Associated Screenshots:
    
<img width="456" alt="Screenshot 2023-10-22 at 15 15 16" src="https://github.com/codu-code/codu/assets/58437550/5341efa0-922b-4d43-9fa5-82bb86d14c81">
