### PR TITLE
fix: sidebar color is now white in lightmode

### DIFF
--- a/components/ArticleMenu/ArticleMenu.tsx
+++ b/components/ArticleMenu/ArticleMenu.tsx
@@ -109,7 +109,7 @@ const ArticleMenu = ({
       enterFrom="transform opacity-0 scale-75"
       enterTo="transform opacity-100 scale-100"
     >
-      <div className="bg-neutral-100 dark:bg-neutral-900 border-t border-neutral-700 fixed lg:w-20 lg:border-r lg:border-b bottom-0 w-full py-2 z-20 lg:top-1/2 lg:-translate-y-1/2 lg:h-56 lg:px-2">
+      <div className="bg-white dark:bg-neutral-900 border-t border-neutral-700 fixed lg:w-20 lg:border-r lg:border-b bottom-0 w-full py-2 z-20 lg:top-1/2 lg:-translate-y-1/2 lg:h-56 lg:px-2">
         <div className="flex justify-evenly lg:flex-col h-full">
           <div className="flex items-center lg:flex-col">
             <button


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

👉 _**Please remove the below and replace with your own values, leaving the headers where they are.**_ 👈

## Pull Request details:🤜
- Fixes- #597
- Background of the menu is set to be bg-white 

## Any Breaking changes:
- None

## Associated Screenshots:
 - Before: 
<img width="757" alt="z" src="https://github.com/codu-code/codu/assets/106615670/e2e19eb6-b605-4a81-9b50-38ffa84bd738">

 - After:
 - Desktop:
![x](https://github.com/codu-code/codu/assets/106615670/04621af2-43a6-433f-b726-09ae5269b34a)
- Mobile:
![y](https://github.com/codu-code/codu/assets/106615670/f194ad2f-a0ee-470f-af70-3c7ea1768def)
