### PR TITLE
Fix: Report backdrop now hides all elements

### DIFF
--- a/components/ArticleMenu/ArticleMenu.tsx
+++ b/components/ArticleMenu/ArticleMenu.tsx
@@ -109,7 +109,7 @@ const ArticleMenu = ({
       enterFrom="transform opacity-0 scale-75"
       enterTo="transform opacity-100 scale-100"
     >
-      <div className="bg-neutral-100 dark:bg-neutral-900 border-t border-neutral-700 fixed lg:w-20 lg:border-r lg:border-b bottom-0 w-full py-2 z-20 lg:top-1/2 lg:-translate-y-1/2 lg:h-56 lg:px-2">
+      <div className="bg-white dark:bg-neutral-900 border-t border-neutral-700 fixed lg:w-20 lg:border-r lg:border-b bottom-0 w-full py-2 z-20 lg:top-1/2 lg:-translate-y-1/2 lg:h-56 lg:px-2">
         <div className="flex justify-evenly lg:flex-col h-full">
           <div className="flex items-center lg:flex-col">
             <button

--- a/components/ReportModal/ReportModal.tsx
+++ b/components/ReportModal/ReportModal.tsx
@@ -108,6 +108,7 @@ export const ReportModal = (props: Props) => {
         open={isModalOpen}
         onClose={() => setIsModalOpen(false)}
         initialFocus={textAreaRef}
+        className="relative z-50"
       >
         <div className="fixed inset-0 bg-gray-700/90" aria-hidden="true" />
         <div className="fixed inset-0 flex w-screen items-center justify-center">


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

👉 _**Please remove the below and replace with your own values, leaving the headers where they are.**_ 👈

## Pull Request details:🤜
- Fixes: #595 
- Moved the report modal up in relative z.

## Any Breaking changes:
- Seems to be none.

## Associated Screenshots:
- Before:
<img width="1719" alt="z" src="https://github.com/codu-code/codu/assets/106615670/c5401523-3163-4f47-ad60-817a4728e00e">
- After:

- Desktop:
![x](https://github.com/codu-code/codu/assets/106615670/c8f200d5-b4ab-4ac9-bcd8-045f2a4da986)
- Mobile:
![y](https://github.com/codu-code/codu/assets/106615670/4e0711fc-24eb-4967-bb0d-382009158ddd)
