### PR TITLE
remove overflow hidden from sidebar

### DIFF
--- a/components/SideBar/SideBarSavedPosts.tsx
+++ b/components/SideBar/SideBarSavedPosts.tsx
@@ -16,7 +16,7 @@ export default React.memo(function SideBarSavedPosts() {
   if (bookmarks) bookmarks = bookmarks.slice(0, howManySavedToShow);
 
   return (
-    <div className="w-full overflow-hidden">
+    <div className="w-full">
       <h3 className="mb-4 mt-8 text-2xl font-semibold leading-6 tracking-wide">
         Recent bookmarks
       </h3>


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

👉 _**Please remove the below and replace with your own values, leaving the headers where they are.**_ 👈

## Pull Request details:
Border on button active state is not visible. 

I originally included an overflow hidden for the sidebar, which I have now removed.
At the time I was adding test posts, with titles which were just a long mash of charachters. ie 
ashdfklhfkjsadhfkashjdfjkashfsdakjhfgkashfasfdjhasldfhsdsafsdf :)

These overflowed the container. I dont think that will be an issue, so I have simply removed 'overflow-hidden' in this pr. 

## Associated Screenshots:
    
![button](https://github.com/codu-code/codu/assets/107807466/77f82328-86ce-4694-a169-a92f30f3c113)
