### PR TITLE
fix: replace loader to fix endless load

### DIFF
--- a/components/ProgressBar/ProgressBar.tsx
+++ b/components/ProgressBar/ProgressBar.tsx
@@ -1,17 +1,7 @@
 "use client";
 import HolyLoader from "holy-loader";
-import { usePathname, useSearchParams } from "next/navigation";
-import { useEffect } from "react";
-import { done as _done } from "nprogress";
 
 const ProgressBar = () => {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-
-  useEffect(() => {
-    _done(true);
-  }, [pathname, searchParams]);
-
   return (
     <HolyLoader
       easing="linear"

--- a/components/ProgressBar/ProgressBar.tsx
+++ b/components/ProgressBar/ProgressBar.tsx
@@ -1,5 +1,5 @@
 "use client";
-import NextTopLoader from "nextjs-toploader";
+import HolyLoader from "holy-loader";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 import { done as _done } from "nprogress";
@@ -13,10 +13,15 @@ const ProgressBar = () => {
   }, [pathname, searchParams]);
 
   return (
-    <NextTopLoader
+    <HolyLoader
       easing="linear"
-      showSpinner={false}
-      template='<div class="bar" role="bar"><div class="gradient"></div></div>'
+      color="linear-gradient(
+        to right,
+        rgb(251, 146, 60),
+        rgb(219, 39, 119)
+      )"
+      zIndex={50}
+      height="0.25rem"
     />
   );
 };

--- a/components/PromptService/PromptLink.tsx
+++ b/components/PromptService/PromptLink.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from "next/navigation";
-import { start, done } from "nprogress";
 import { usePrompt } from "@/components/PromptService/PromptContext";
-import { useEffect, useState, ReactNode } from "react";
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { PromptDialog } from "./PromptDialog";
 
@@ -32,13 +32,11 @@ export const PromptLink = ({ to, children, className }: LinkProps) => {
   const confirmNavigation = () => {
     setShowModal(false);
     setHasPrompt(false);
-    start();
     router.push(to);
   };
 
   const cancelNavigation = () => {
     setShowModal(false);
-    done(true);
     return false;
   };
 
@@ -46,8 +44,6 @@ export const PromptLink = ({ to, children, className }: LinkProps) => {
     if (hasPrompt === true) {
       setHasPrompt(false);
     }
-
-    done(true);
   }, [hasPrompt]);
 
   return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "fathom-client": "^3.6.0",
         "framer-motion": "^10.16.16",
         "highlight.js": "^11.9.0",
+        "holy-loader": "^2.0.1",
         "lowlight": "^3.1.0",
         "lucide-react": "^0.294.0",
         "nanoid": "^5.0.4",
@@ -10192,6 +10193,14 @@
     "node_modules/hoist-non-react-statics/node_modules/react-is": {
       "version": "16.13.1",
       "license": "MIT"
+    },
+    "node_modules/holy-loader": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/holy-loader/-/holy-loader-2.0.1.tgz",
+      "integrity": "sha512-4pbeWO0qRUvYY2r1NNY3wyOZz6c/HQ2d30VyrN7GFUCuvbxycBzffwppTwhJJS4n2PY1CBAKjB/cAV7TDyVFWg==",
+      "dependencies": {
+        "react": "^18.2.0"
+      }
     },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,6 @@
         "next-auth": "^4.24.5",
         "next-superjson-plugin": "^0.5.10",
         "next-themes": "^0.2.1",
-        "nextjs-toploader": "^1.6.4",
         "nodemailer": "^6.9.7",
         "prismjs": "^1.29.0",
         "react": "^18.2.0",
@@ -6606,10 +6605,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/nprogress": {
-      "version": "0.2.3",
-      "license": "MIT"
-    },
     "node_modules/@types/object.omit": {
       "version": "3.0.3",
       "license": "MIT"
@@ -12999,20 +12994,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/nextjs-toploader": {
-      "version": "1.6.4",
-      "license": "MIT",
-      "dependencies": {
-        "@types/nprogress": "^0.2.1",
-        "nprogress": "^0.2.0",
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "next": ">= 6.0.0",
-        "react": ">= 16.0.0",
-        "react-dom": ">= 16.0.0"
-      }
-    },
     "node_modules/no-case": {
       "version": "3.0.4",
       "dev": true,
@@ -13098,11 +13079,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/nprogress": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
-      "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA=="
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -13968,6 +13944,7 @@
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -13977,6 +13954,7 @@
     },
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/prosemirror-changeset": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "next-auth": "^4.24.5",
     "next-superjson-plugin": "^0.5.10",
     "next-themes": "^0.2.1",
-    "nextjs-toploader": "^1.6.4",
     "nodemailer": "^6.9.7",
     "prismjs": "^1.29.0",
     "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "fathom-client": "^3.6.0",
     "framer-motion": "^10.16.16",
     "highlight.js": "^11.9.0",
+    "holy-loader": "^2.0.1",
     "lowlight": "^3.1.0",
     "lucide-react": "^0.294.0",
     "nanoid": "^5.0.4",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -358,19 +358,3 @@ table div {
     transform: translate(24px, 0);
   }
 }
-
-@layer {
-  .gradient {
-    background-image: linear-gradient(
-      to right,
-      rgb(251, 146, 60),
-      rgb(219, 39, 119)
-    );
-    height: 0.25rem;
-    width: 100%;
-    left: 0px;
-    top: 0px;
-    position: fixed;
-    z-index: 50;
-  }
-}


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

## Pull Request details:
- Fixes: https://github.com/codu-code/codu/issues/672

## Any Breaking changes:
- There seem to have been some legacy `done()` & `start()` calls in the `<PromptLink />` component. They looked safe to remove though. Looking forward to the Vercel preview to test all pages (cannot auth on localhost)

⚠️ I have assumed that the `.gradient` css class is safe to delete as it was only used by the old loader. Please double-check this ❤️

## TODO
If this looks good to you, I would also remove the `<ProgressBar />` component altogether (since it is basically empty now) and place `<HolyLoader />` directly in `layout.tsx`

## Associated Screenshots:
    
Loader before:
![A screenshot of the old loader](https://github.com/codu-code/codu/assets/35841182/f5e0bcb5-7440-4ff3-a282-67909cad08d4)
Loader after:
![A screenshot of the new loader](https://github.com/codu-code/codu/assets/35841182/43cd9bc1-8bf9-4891-9965-7f5a926554d2)