### PR TITLE
Add client-side rendering support for Media component

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,5 +7,7 @@ dist/
 # build
 build/
 
+# editor because it is breaking things... Needs fixing
+components/editor/editor/
 
 

--- a/components/CustomTextareAutosize/CustomTextareaAutosize.tsx
+++ b/components/CustomTextareAutosize/CustomTextareaAutosize.tsx
@@ -1,7 +1,7 @@
-import React, { forwardRef, Ref, ForwardRefRenderFunction } from "react";
-import TextareaAutosize, {
-  TextareaAutosizeProps,
-} from "react-textarea-autosize";
+import type { Ref, ForwardRefRenderFunction } from "react";
+import React, { forwardRef } from "react";
+import type { TextareaAutosizeProps } from "react-textarea-autosize";
+import TextareaAutosize from "react-textarea-autosize";
 
 interface TextareaAutosizeWrapperProps extends TextareaAutosizeProps {
   inputRef?: Ref<HTMLTextAreaElement>;

--- a/components/ImageDetailsModal/ImageDetailsModal.tsx
+++ b/components/ImageDetailsModal/ImageDetailsModal.tsx
@@ -1,5 +1,6 @@
-import { Dispatch, SetStateAction, useRef } from "react";
-import { Editor } from "@tiptap/core";
+import type { Dispatch, SetStateAction } from "react";
+import { useRef } from "react";
+import type { Editor } from "@tiptap/core";
 import { Modal } from "@/components/Modal/Modal";
 import { XIcon } from "lucide-react";
 import { z } from "zod";

--- a/components/editor/editor/components/CodeBlock/CodeBlock.tsx
+++ b/components/editor/editor/components/CodeBlock/CodeBlock.tsx
@@ -1,5 +1,6 @@
-import { NodeViewContent, NodeViewProps, NodeViewWrapper } from "@tiptap/react";
-import { ChangeEvent, FunctionComponent } from "react";
+import type { NodeViewProps } from "@tiptap/react";
+import { NodeViewContent, NodeViewWrapper } from "@tiptap/react";
+import type { ChangeEvent, FunctionComponent } from "react";
 
 import styles from "./CodeBlock.module.css";
 

--- a/components/editor/editor/components/Table/CustomTableNodeView.tsx
+++ b/components/editor/editor/components/Table/CustomTableNodeView.tsx
@@ -1,4 +1,5 @@
-import { NodeViewContent, NodeViewProps, NodeViewWrapper } from "@tiptap/react";
+import type { NodeViewProps } from "@tiptap/react";
+import { NodeViewContent, NodeViewWrapper } from "@tiptap/react";
 import {
   BookmarkMinus,
   ColumnsIcon,
@@ -6,7 +7,7 @@ import {
   RowsIcon,
   Trash2Icon,
 } from "lucide-react";
-import { FunctionComponent, ReactNode } from "react";
+import type { FunctionComponent, ReactNode } from "react";
 
 import styles from "../Toolbar/Toolbar.module.css";
 

--- a/components/editor/editor/components/Toolbar/ToolbarItemButton.tsx
+++ b/components/editor/editor/components/Toolbar/ToolbarItemButton.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, ReactNode } from "react";
+import type { FunctionComponent, ReactNode } from "react";
 
 import styles from "./Toolbar.module.css";
 

--- a/components/editor/editor/components/bubble-menu.tsx
+++ b/components/editor/editor/components/bubble-menu.tsx
@@ -1,5 +1,7 @@
-import { BubbleMenu, BubbleMenuProps } from "@tiptap/react";
-import { FC, useState } from "react";
+import type { BubbleMenuProps } from "@tiptap/react";
+import { BubbleMenu } from "@tiptap/react";
+import type { FC } from "react";
+import { useState } from "react";
 import {
   BoldIcon,
   ItalicIcon,

--- a/components/editor/editor/components/color-selector.tsx
+++ b/components/editor/editor/components/color-selector.tsx
@@ -1,6 +1,6 @@
-import { Editor } from "@tiptap/core";
+import type { Editor } from "@tiptap/core";
 import { Check, ChevronDown } from "lucide-react";
-import { Dispatch, FC, SetStateAction } from "react";
+import type { Dispatch, FC, SetStateAction } from "react";
 
 export interface BubbleColorMenuItem {
   name: string;

--- a/components/editor/editor/components/link-selector.tsx
+++ b/components/editor/editor/components/link-selector.tsx
@@ -1,14 +1,8 @@
 import { cn, getUrlFromString } from "@/utils/utils";
-import { Editor } from "@tiptap/core";
+import type { Editor } from "@tiptap/core";
 import { Check, Trash } from "lucide-react";
-import {
-  Dispatch,
-  FC,
-  SetStateAction,
-  useEffect,
-  useRef,
-  useCallback,
-} from "react";
+import type { Dispatch, FC, SetStateAction } from "react";
+import { useEffect, useRef, useCallback } from "react";
 
 interface LinkSelectorProps {
   editor: Editor;

--- a/components/editor/editor/components/node-selector.tsx
+++ b/components/editor/editor/components/node-selector.tsx
@@ -1,4 +1,4 @@
-import { Editor } from "@tiptap/core";
+import type { Editor } from "@tiptap/core";
 import {
   Check,
   ChevronDown,
@@ -12,9 +12,9 @@ import {
   CheckSquare,
   Heading,
 } from "lucide-react";
-import { Dispatch, FC, SetStateAction } from "react";
+import type { Dispatch, FC, SetStateAction } from "react";
 
-import { BubbleMenuItem } from "./bubble-menu";
+import type { BubbleMenuItem } from "./bubble-menu";
 
 interface NodeSelectorProps {
   editor: Editor;

--- a/components/editor/editor/extensions/index.tsx
+++ b/components/editor/editor/extensions/index.tsx
@@ -27,7 +27,8 @@ import Table from "@tiptap/extension-table";
 import TableCell from "@tiptap/extension-table-cell";
 import TableHeader from "@tiptap/extension-table-header";
 import TableRow from "@tiptap/extension-table-row";
-import { ReactNodeViewRenderer, NodeViewProps } from "@tiptap/react";
+import type { NodeViewProps } from "@tiptap/react";
+import { ReactNodeViewRenderer } from "@tiptap/react";
 import CustomTableNodeView from "../components/Table/CustomTableNodeView";
 import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
 

--- a/components/editor/editor/props.ts
+++ b/components/editor/editor/props.ts
@@ -1,4 +1,4 @@
-import { EditorProps } from "@tiptap/pm/view";
+import type { EditorProps } from "@tiptap/pm/view";
 import { startImageUpload } from "@/components/editor/editor/plugins/upload-images";
 
 export const TiptapEditorProps: EditorProps = {

--- a/components/markdocNodes/Media/Media.tsx
+++ b/components/markdocNodes/Media/Media.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 import { YouTube } from "../Youtube/Youtube";
 import { CodePen } from "../CodePen/CodePen";

--- a/package-lock.json
+++ b/package-lock.json
@@ -9241,8 +9241,9 @@
     },
     "node_modules/eslint-plugin-jsx-a11y": {
       "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.8.0.tgz",
+      "integrity": "sha512-Hdh937BS3KdwwbBaKd5+PLCOmYY6U4f2h9Z2ktwtNKvIdIEu137rjYbcb9ApSbVJfWxANNuiKTD/9tOKjK9qOA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.2",
         "aria-query": "^5.3.0",


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

## Pull Request details:
Not using `"use client";` on the media component was causing all pages with media to crash.

- Add client-side rendering support for the Media component
- Fix linting issues

## Any Breaking changes:
- None
