### PR TITLE
686 - Fix canonical url bug and update default values

### DIFF
--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   const post = await getPost({ slug });
 
-  // Might revisit to give more defaults
+  // @TODO revisit to give more defaults
   const tags = post?.tags.map((tag) => tag.tag.title);
 
   if (!post) return {};

--- a/app/create/[[...paramsArr]]/_client.tsx
+++ b/app/create/[[...paramsArr]]/_client.tsx
@@ -39,7 +39,7 @@ const Create = () => {
     usePrompt();
 
   useEffect(() => {
-    _setUnsaved(unsavedChanges);
+    _setUnsaved();
   }, [unsavedChanges, _setUnsaved]);
 
   const allowUpdate = unsavedChanges;
@@ -350,7 +350,9 @@ const Create = () => {
                               id="canonicalUrl"
                               type="text"
                               placeholder="https://www.somesite.com/i-posted-here-first"
-                              defaultValue=""
+                              defaultValue={
+                                data?.canonicalUrl ? data.canonicalUrl : ""
+                              }
                               {...register("canonicalUrl")}
                             />
                             <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">

--- a/server/api/router/post.ts
+++ b/server/api/router/post.ts
@@ -96,7 +96,7 @@ export const postRouter = createTRPCRouter({
           title,
           excerpt: getExcerptValue() || "",
           readTimeMins: readingTime(body),
-          canonicalUrl,
+          canonicalUrl: !!canonicalUrl ? canonicalUrl : null,
         },
       });
       return post;


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

## Pull Request details:
- Show default value in canonical url input so that it is clear to user that it is set
- Allow user to remove canonical url by setting `null` value. `undefined` tells Prisma to ignore the value (and not update) 🤦  My bad! 

## Any Breaking changes:
- None, fixes broken canonical url. 

Closes #686