### PR TITLE
pass close fn/forwardref to promptlink

### DIFF
--- a/components/Nav/MobileNav.tsx
+++ b/components/Nav/MobileNav.tsx
@@ -2,7 +2,7 @@ import { type UserNavigationItem } from "@/types/types";
 import { Disclosure, Transition } from "@headlessui/react";
 import { type Session } from "next-auth";
 import { PromptLink as Link } from "../PromptService/PromptLink";
-import { type FunctionComponent } from "react";
+import { MutableRefObject, useRef, type FunctionComponent } from "react";
 import { navigation, subNav, userSubNav } from "../../config/site_settings";
 
 function classNames(...classes: string[]) {
@@ -12,11 +12,18 @@ function classNames(...classes: string[]) {
 interface MobileNavProps {
   session: Session | null;
   userNavigation: UserNavigationItem[];
+  close?: (
+    focusableElement?:
+      | HTMLElement
+      | MutableRefObject<HTMLElement | null>
+      | undefined,
+  ) => void;
 }
 
 const MobileNav: FunctionComponent<MobileNavProps> = ({
   session,
   userNavigation,
+  close,
 }) => {
   return (
     <Transition
@@ -31,7 +38,7 @@ const MobileNav: FunctionComponent<MobileNavProps> = ({
             <NavItem item={item} key={item.name} />
           ))}
           <div className="flex flex-col space-y-1 border-t border-neutral-400 pb-3 pt-3 dark:border-neutral-600">
-            <SubNav session={session} />
+            <SubNav session={session} close={close} />
           </div>
         </div>
 
@@ -123,9 +130,16 @@ const NavItem: FunctionComponent<NavItemProps> = ({ item }) => {
 
 interface SubNavProps {
   session: Session | null;
+  close?: (
+    focusableElement?:
+      | HTMLElement
+      | MutableRefObject<HTMLElement | null>
+      | undefined,
+  ) => void;
 }
 
-const SubNav: FunctionComponent<SubNavProps> = ({ session }) => {
+const SubNav: FunctionComponent<SubNavProps> = ({ session, close }) => {
+  const disclosureButtonRef = useRef(null);
   const data = session ? userSubNav : subNav;
   return (
     <>
@@ -134,6 +148,8 @@ const SubNav: FunctionComponent<SubNavProps> = ({ session }) => {
           <Disclosure.Button
             as={Link}
             to={item.href}
+            close={close}
+            ref={disclosureButtonRef}
             className={classNames(
               item.fancy
                 ? "block justify-center bg-gradient-to-r from-orange-400 to-pink-600 px-4 text-white shadow-sm hover:from-orange-300 hover:to-pink-500 focus:outline-none focus:ring-2 focus:ring-offset-2"

--- a/components/Nav/Nav.tsx
+++ b/components/Nav/Nav.tsx
@@ -34,7 +34,7 @@ const Nav = ({ session }: { session: Session | null }) => {
 
   return (
     <Disclosure as="nav" className="bg-neutral-100 dark:bg-black">
-      {({ open }) => (
+      {({ close, open }) => (
         <>
           <div className="relative z-20 mx-auto px-4 sm:px-6 lg:px-8">
             <div className="flex h-16 items-center justify-between">
@@ -197,7 +197,11 @@ const Nav = ({ session }: { session: Session | null }) => {
               </div>
             </div>
           </div>
-          <MobileNav session={session} userNavigation={userNavigation} />
+          <MobileNav
+            session={session}
+            userNavigation={userNavigation}
+            close={close}
+          />
         </>
       )}
     </Disclosure>

--- a/components/PromptService/PromptLink.tsx
+++ b/components/PromptService/PromptLink.tsx
@@ -1,66 +1,90 @@
 import { useRouter } from "next/navigation";
 import { usePrompt } from "@/components/PromptService/PromptContext";
-import type { ReactNode } from "react";
+import type { MutableRefObject, ReactNode } from "react";
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { PromptDialog } from "./PromptDialog";
+import React from "react";
 
 interface LinkProps {
   to: string;
   children: ReactNode;
   className?: string;
+  close?: (
+    focusableElement?:
+      | HTMLElement
+      | MutableRefObject<HTMLElement | null>
+      | undefined,
+  ) => void;
 }
 
-export const PromptLink = ({ to, children, className }: LinkProps) => {
-  const router = useRouter();
-  const { unsavedChanges } = usePrompt();
-  const [hasPrompt, setHasPrompt] = useState(false);
-  const [showModal, setShowModal] = useState(false);
+const PromptLink = React.forwardRef(
+  (
+    { to, children, className, close }: LinkProps,
+    ref: React.Ref<HTMLAnchorElement>,
+  ) => {
+    const router = useRouter();
+    const { unsavedChanges } = usePrompt();
+    const [hasPrompt, setHasPrompt] = useState(false);
+    const [showModal, setShowModal] = useState(false);
 
-  const handleNavigation = (event) => {
-    event.preventDefault();
+    const handleNavigation = (
+      event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
+    ) => {
+      event.preventDefault();
 
-    if (unsavedChanges) {
-      setHasPrompt(true);
-      setShowModal(true);
-      return false;
-    } else {
-      router.push(to);
-    }
-  };
+      if (unsavedChanges) {
+        setHasPrompt(true);
+        setShowModal(true);
+        return false;
+      } else {
+        if (close !== undefined) close();
+        router.push(to);
+      }
+    };
 
-  const confirmNavigation = () => {
-    setShowModal(false);
-    setHasPrompt(false);
-    router.push(to);
-  };
-
-  const cancelNavigation = () => {
-    setShowModal(false);
-    return false;
-  };
-
-  useEffect(() => {
-    if (hasPrompt === true) {
+    const confirmNavigation = () => {
+      setShowModal(false);
       setHasPrompt(false);
-    }
-  }, [hasPrompt]);
+      if (close !== undefined) close();
+      router.push(to);
+    };
 
-  return (
-    <>
-      <Link href={to} onClick={handleNavigation} className={className}>
-        {children}
-      </Link>
-      {showModal && (
-        <PromptDialog
-          title="Unsaved Changes"
-          subTitle="You have unsaved changes. Are you sure you want to leave?"
-          confirm={confirmNavigation}
-          cancel={cancelNavigation}
-          confirmText="Continue without saving"
-          cancelText="Keep editing"
-        />
-      )}
-    </>
-  );
-};
+    const cancelNavigation = () => {
+      setShowModal(false);
+      return false;
+    };
+
+    useEffect(() => {
+      if (hasPrompt === true) {
+        setHasPrompt(false);
+      }
+    }, [hasPrompt]);
+
+    return (
+      <>
+        <Link
+          href={to}
+          onClick={handleNavigation}
+          className={className}
+          ref={ref}
+        >
+          {children}
+        </Link>
+        {showModal && (
+          <PromptDialog
+            title="Unsaved Changes"
+            subTitle="You have unsaved changes. Are you sure you want to leave?"
+            confirm={confirmNavigation}
+            cancel={cancelNavigation}
+            confirmText="Continue without saving"
+            cancelText="Keep editing"
+          />
+        )}
+      </>
+    );
+  },
+);
+
+PromptLink.displayName = "PromptLink";
+export { PromptLink };


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

## Pull Request details

The dropdown nav is a headless UI disclosure, usually handles closing. From docs >>
To close a disclosure manually when clicking a child of its panel, render that child as a Disclosure.Button. You can use the ‘as’ prop to customize which element is being rendered.

However in this case it is not working, because the as prop is passed the PromptLink component. 
<Disclosure.Button
        	as={Link}   // import Link as PromptLink
        	to={item.href}
>
{item.name}
</Disclosure.Button>

Fix
The disclosure component exposes a close render prop, which I drill down and invoke in the PromptLink component.
Nav > MobileNav > SubNav > PromptLink

Note:
Before I made modifications to the code, a forwardRef error was being displayed in the console. I resolved this issue by introducing a ref to the disclosure button, passing it as a forwardRef to PromptLink, and then applying the ref to the next/Link component.

I also added a displayName to the PromptLink component to please the linting gods.

## Any Breaking changes

None

## Associated Screenshots

- IF YOU HAVE ANY SCREENSHOTS, INCLUDE THEM HERE. _( Welcome file extensions include gifs/png screenshots of your feature in action )_
- None
