### PR TITLE
fix: added validation for username (only alphanumeric and dashes allowed)

### DIFF
--- a/schema/profile.ts
+++ b/schema/profile.ts
@@ -3,7 +3,14 @@ import z from "zod";
 export const saveSettingsSchema = z.object({
   name: z.string().min(1).max(50),
   bio: z.string().max(200).optional(),
-  username: z.string().min(3).max(40, "Max username length is 40 characters."),
+  username: z
+    .string()
+    .min(3)
+    .max(40, "Max username length is 40 characters.")
+    .regex(
+      /^[a-zA-Z0-9-]+$/,
+      "Username can only contain alphanumerics and dashes.",
+    ),
   location: z
     .string()
     .max(100, "Max location length is 100 characters.")


### PR DESCRIPTION
…wed)

# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

## Pull Request details

Added validation in saveSettingsSchema (schema/profile.ts). I used regex for validation, just added one more rule to zod schema and error validation message ("Username can only contain alphanumerics and dashes.")


![image](https://github.com/codu-code/codu/assets/35420719/4584691f-5355-45c7-bb3f-c8a1fc96cb87)
