### PR TITLE
Patch/heading styles

### DIFF
--- a/components/editor/editor/components/bubble-menu.tsx
+++ b/components/editor/editor/components/bubble-menu.tsx
@@ -20,7 +20,7 @@ export interface BubbleMenuItem {
   icon: typeof BoldIcon;
 }
 
-type EditorBubbleMenuProps = Omit<BubbleMenuProps, "children">;
+type EditorBubbleMenuProps = Omit<Required<Pick<BubbleMenuProps, "editor">> & BubbleMenuProps, "children">;
 
 export const EditorBubbleMenu: FC<EditorBubbleMenuProps> = (props) => {
   const items: BubbleMenuItem[] = [
@@ -53,8 +53,8 @@ export const EditorBubbleMenu: FC<EditorBubbleMenuProps> = (props) => {
   const bubbleMenuProps: EditorBubbleMenuProps = {
     ...props,
     shouldShow: ({ editor }) => {
-      // don't show if image is selected
-      if (editor.isActive("image")) {
+      // don't show if image is selected or a heading
+      if (editor.isActive("image") || editor.isActive("heading")) {
         return false;
       }
 

--- a/components/editor/editor/extensions/disable-heading-text-style-shortcuts.tsx
+++ b/components/editor/editor/extensions/disable-heading-text-style-shortcuts.tsx
@@ -1,0 +1,17 @@
+import { Extension } from "@tiptap/react";
+
+const DisableHeadingTextStyleShortcuts = Extension.create({
+  addKeyboardShortcuts() {
+    // If the selected node is a heading, disable the text style shortcuts
+    return {
+      'Mod-b': () => this.editor.isActive("heading") ?? this.editor.commands.toggleBold(),
+      'Mod-i': () => this.editor.isActive("heading") ?? this.editor.commands.toggleItalic(),
+      'Mod-u': () => this.editor.isActive("heading") ?? this.editor.commands.toggleUnderline(),
+      'Mod-e': () => this.editor.isActive("heading") ?? this.editor.commands.toggleCode(),
+      'Mod-shift-x': () => this.editor.isActive("heading") ?? this.editor.commands.toggleStrike(),
+      'Mod-shift-h': () => this.editor.isActive("heading") ?? this.editor.commands.toggleHighlight(),
+    };
+  },
+})
+
+export default DisableHeadingTextStyleShortcuts;

--- a/components/editor/editor/extensions/disable-heading-text-style-shortcuts.tsx
+++ b/components/editor/editor/extensions/disable-heading-text-style-shortcuts.tsx
@@ -8,7 +8,7 @@ const DisableHeadingTextStyleShortcuts = Extension.create({
       'Mod-i': () => this.editor.isActive("heading") ?? this.editor.commands.toggleItalic(),
       'Mod-u': () => this.editor.isActive("heading") ?? this.editor.commands.toggleUnderline(),
       'Mod-e': () => this.editor.isActive("heading") ?? this.editor.commands.toggleCode(),
-      'Mod-shift-x': () => this.editor.isActive("heading") ?? this.editor.commands.toggleStrike(),
+      'Mod-shift-s': () => this.editor.isActive("heading") ?? this.editor.commands.toggleStrike(),
       'Mod-shift-h': () => this.editor.isActive("heading") ?? this.editor.commands.toggleHighlight(),
     };
   },

--- a/components/editor/editor/extensions/index.tsx
+++ b/components/editor/editor/extensions/index.tsx
@@ -2,8 +2,6 @@ import StarterKit from "@tiptap/starter-kit";
 import HorizontalRule from "@tiptap/extension-horizontal-rule";
 import TiptapLink from "@tiptap/extension-link";
 import Link from "@tiptap/extension-link";
-import TiptapImage from "@tiptap/extension-image";
-import Image from "@tiptap/extension-image";
 import Placeholder from "@tiptap/extension-placeholder";
 import TiptapUnderline from "@tiptap/extension-underline";
 import TextStyle from "@tiptap/extension-text-style";
@@ -12,7 +10,6 @@ import { Markdown } from "tiptap-markdown";
 import Highlight from "@tiptap/extension-highlight";
 import SlashCommand from "./slash-command";
 import { InputRule } from "@tiptap/core";
-// import UploadImagesPlugin from "@/components/editor/editor/plugins/upload-images";
 import UpdatedImage from "./updated-image";
 import Document from "@tiptap/extension-document";
 import Paragraph from "@tiptap/extension-paragraph";
@@ -21,7 +18,6 @@ import TextAlign from "@tiptap/extension-text-align";
 import Subscript from "@tiptap/extension-subscript";
 import Superscript from "@tiptap/extension-superscript";
 import Youtube from "@tiptap/extension-youtube";
-import UpdatedYoutube from "./update-youtube";
 
 import Table from "@tiptap/extension-table";
 import TableCell from "@tiptap/extension-table-cell";
@@ -39,6 +35,7 @@ const lowlight = createLowlight(common);
 import "highlight.js/styles/monokai-sublime.css";
 
 import CodeBlock from "../components/CodeBlock/CodeBlock";
+import DisableHeadingTextStyleShortcuts from "./disable-heading-text-style-shortcuts";
 
 // const CustomImage = TiptapImage.extend({
 //   addProseMirrorPlugins() {
@@ -221,4 +218,5 @@ export const TiptapExtensions = [
     height: 320,
     allowFullscreen: true,
   }),
+  DisableHeadingTextStyleShortcuts,
 ];


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

## Pull Request details

- Resolves #566 
- Added a new extension that disables some text formatting shortcuts if the selected text is a `heading`
- Removed some unused imports from `/editor/extensions/index.tsx`
- Improved `EditorBubbleMenuProps` type since `editor` is `required`.
- Disables `Bubble Menu` if the selected text is a `heading`

## Any Breaking changes

- None

## Associated Screenshots
![image](https://github.com/codu-code/codu/assets/18503860/80e669c0-654b-4256-b659-238a1be329e2)

