### PR TITLE
Expose drizzle in tRPC context

### DIFF
--- a/server/api/router/admin.ts
+++ b/server/api/router/admin.ts
@@ -10,7 +10,7 @@ export const adminRouter = createTRPCRouter({
       const { userId, note } = input;
       const currentUserId = ctx.session.user.id;
 
-      const user = await ctx.db.user.findFirstOrThrow({
+      const user = await ctx.prisma.user.findFirstOrThrow({
         where: {
           id: userId,
         },
@@ -22,14 +22,14 @@ export const adminRouter = createTRPCRouter({
         });
       }
 
-      await ctx.db.bannedUsers.create({
+      await ctx.prisma.bannedUsers.create({
         data: {
           userId,
           note,
           bannedById: currentUserId,
         },
       });
-      await ctx.db.session.deleteMany({
+      await ctx.prisma.session.deleteMany({
         where: {
           userId,
         },
@@ -42,7 +42,7 @@ export const adminRouter = createTRPCRouter({
     .mutation(async ({ input, ctx }) => {
       const { userId } = input;
 
-      await ctx.db.bannedUsers.deleteMany({
+      await ctx.prisma.bannedUsers.deleteMany({
         where: {
           userId,
         },

--- a/server/api/router/comment.ts
+++ b/server/api/router/comment.ts
@@ -19,7 +19,7 @@ export const commentRouter = createTRPCRouter({
       const { body, postId, parentId } = input;
       const userId = ctx.session.user.id;
 
-      const postData = await ctx.db.post.findUnique({
+      const postData = await ctx.prisma.post.findUnique({
         where: {
           id: postId,
         },
@@ -30,7 +30,7 @@ export const commentRouter = createTRPCRouter({
 
       const postOwnerId = postData?.userId;
 
-      const { id } = await ctx.db.comment.create({
+      const { id } = await ctx.prisma.comment.create({
         data: {
           userId,
           body,
@@ -40,7 +40,7 @@ export const commentRouter = createTRPCRouter({
       });
 
       if (parentId) {
-        const commentData = await ctx.db.comment.findUnique({
+        const commentData = await ctx.prisma.comment.findUnique({
           where: {
             id: parentId,
           },
@@ -49,7 +49,7 @@ export const commentRouter = createTRPCRouter({
           },
         });
         if (commentData?.userId && commentData?.userId !== userId) {
-          await ctx.db.notification.create({
+          await ctx.prisma.notification.create({
             data: {
               notifierId: userId,
               type: NEW_REPLY_TO_YOUR_COMMENT,
@@ -62,7 +62,7 @@ export const commentRouter = createTRPCRouter({
       }
 
       if (!parentId && postOwnerId && postOwnerId !== userId) {
-        await ctx.db.notification.create({
+        await ctx.prisma.notification.create({
           data: {
             notifierId: userId,
             type: NEW_COMMENT_ON_YOUR_POST,
@@ -79,7 +79,7 @@ export const commentRouter = createTRPCRouter({
     .input(EditCommentSchema)
     .mutation(async ({ input, ctx }) => {
       const { body, id } = input;
-      const currentComment = await ctx.db.comment.findFirstOrThrow({
+      const currentComment = await ctx.prisma.comment.findFirstOrThrow({
         where: {
           id,
         },
@@ -95,7 +95,7 @@ export const commentRouter = createTRPCRouter({
         return currentComment;
       }
 
-      const comment = await ctx.db.comment.update({
+      const comment = await ctx.prisma.comment.update({
         where: {
           id,
         },
@@ -110,7 +110,7 @@ export const commentRouter = createTRPCRouter({
     .mutation(async ({ input, ctx }) => {
       const { id } = input;
 
-      const currentComment = await ctx.db.comment.findUnique({
+      const currentComment = await ctx.prisma.comment.findUnique({
         where: { id },
       });
 
@@ -120,7 +120,7 @@ export const commentRouter = createTRPCRouter({
         });
       }
 
-      const comment = await ctx.db.comment.delete({
+      const comment = await ctx.prisma.comment.delete({
         where: {
           id,
         },
@@ -134,14 +134,14 @@ export const commentRouter = createTRPCRouter({
       const { commentId } = input;
       const userId = ctx.session.user.id;
 
-      const liked = await ctx.db.like.findUnique({
+      const liked = await ctx.prisma.like.findUnique({
         where: {
           userId_commentId: { userId, commentId },
         },
       });
 
       if (liked) {
-        const res = await ctx.db.like.delete({
+        const res = await ctx.prisma.like.delete({
           where: {
             userId_commentId: { userId, commentId },
           },
@@ -150,7 +150,7 @@ export const commentRouter = createTRPCRouter({
         return res;
       }
 
-      const res = await ctx.db.like.create({
+      const res = await ctx.prisma.like.create({
         data: {
           commentId,
           userId,
@@ -194,13 +194,13 @@ export const commentRouter = createTRPCRouter({
         },
       };
 
-      const count = await ctx.db.comment.count({
+      const count = await ctx.prisma.comment.count({
         where: {
           postId,
         },
       });
 
-      const response = await ctx.db.comment.findMany({
+      const response = await ctx.prisma.comment.findMany({
         where: {
           postId,
           parentId: null,

--- a/server/api/router/community.ts
+++ b/server/api/router/community.ts
@@ -17,7 +17,7 @@ export const communityRouter = createTRPCRouter({
       const filter = input.filter ?? undefined;
       const { cursor } = input;
 
-      const response = await ctx.db.community.findMany({
+      const response = await ctx.prisma.community.findMany({
         take: limit + 1,
         where: {
           name: {
@@ -87,7 +87,7 @@ export const communityRouter = createTRPCRouter({
     .mutation(async ({ input, ctx }) => {
       if (ctx.session.user.id) {
         if (input.id !== null && input.id !== undefined) {
-          const membership = await ctx.db.membership.findFirst({
+          const membership = await ctx.prisma.membership.findFirst({
             where: {
               communityId: input.id,
               userId: ctx.session.user.id,
@@ -104,7 +104,7 @@ export const communityRouter = createTRPCRouter({
             });
           }
 
-          const community = await ctx.db.community.update({
+          const community = await ctx.prisma.community.update({
             where: {
               id: input.id,
             },
@@ -124,7 +124,7 @@ export const communityRouter = createTRPCRouter({
 
           return community;
         } else {
-          const community = await ctx.db.community.create({
+          const community = await ctx.prisma.community.create({
             data: {
               id: nanoid(8),
               slug: `${input.name
@@ -139,7 +139,7 @@ export const communityRouter = createTRPCRouter({
               coverImage: `${input.coverImage}?id=${nanoid(3)}`,
             },
           });
-          const membership = await ctx.db.membership.create({
+          const membership = await ctx.prisma.membership.create({
             data: {
               id: nanoid(8),
               communityId: community.id,
@@ -157,7 +157,7 @@ export const communityRouter = createTRPCRouter({
   createMembership: protectedProcedure
     .input(deleteCommunitySchema)
     .mutation(async ({ input, ctx }) => {
-      await ctx.db.membership.create({
+      await ctx.prisma.membership.create({
         data: {
           id: nanoid(8),
           communityId: input.id,
@@ -169,14 +169,14 @@ export const communityRouter = createTRPCRouter({
   deleteMembership: protectedProcedure
     .input(deleteCommunitySchema)
     .mutation(async ({ input, ctx }) => {
-      const membership = await ctx.db.membership.findFirst({
+      const membership = await ctx.prisma.membership.findFirst({
         where: {
           communityId: input.id,
           userId: ctx.session.user.id,
         },
       });
       if (membership) {
-        await ctx.db.membership.delete({
+        await ctx.prisma.membership.delete({
           where: {
             id: membership.id,
           },

--- a/server/api/router/event.ts
+++ b/server/api/router/event.ts
@@ -15,7 +15,7 @@ export const eventRouter = createTRPCRouter({
     const filter = input.filter ?? undefined;
     const { cursor } = input;
 
-    const response = await ctx.db.event.findMany({
+    const response = await ctx.prisma.event.findMany({
       take: limit + 1,
       where: {
         OR: [
@@ -69,7 +69,7 @@ export const eventRouter = createTRPCRouter({
     .mutation(async ({ input, ctx }) => {
       if (ctx.session.user.id) {
         if (input.id !== null && input.id !== undefined) {
-          const eventSearchResult = await ctx.db.event.findFirst({
+          const eventSearchResult = await ctx.prisma.event.findFirst({
             where: {
               id: input.id,
             },
@@ -84,7 +84,7 @@ export const eventRouter = createTRPCRouter({
             });
           }
 
-          const membership = await ctx.db.membership.findFirst({
+          const membership = await ctx.prisma.membership.findFirst({
             where: {
               communityId: eventSearchResult?.communityId,
               userId: ctx.session.user.id,
@@ -101,7 +101,7 @@ export const eventRouter = createTRPCRouter({
             });
           }
 
-          const event = await ctx.db.event.update({
+          const event = await ctx.prisma.event.update({
             where: {
               id: input.id,
             },
@@ -121,7 +121,7 @@ export const eventRouter = createTRPCRouter({
 
           return event;
         } else {
-          const event = await ctx.db.event.create({
+          const event = await ctx.prisma.event.create({
             data: {
               id: nanoid(8),
               communityId: input.communityId,
@@ -137,7 +137,7 @@ export const eventRouter = createTRPCRouter({
               coverImage: `${input.coverImage}?id=${nanoid(3)}`,
             },
           });
-          const membership = await ctx.db.rSVP.create({
+          const membership = await ctx.prisma.rSVP.create({
             data: {
               id: nanoid(8),
               eventId: event.id,
@@ -184,7 +184,7 @@ export const eventRouter = createTRPCRouter({
   createRSVP: protectedProcedure
     .input(deleteEventSchema)
     .mutation(async ({ input, ctx }) => {
-      await ctx.db.rSVP.create({
+      await ctx.prisma.rSVP.create({
         data: {
           id: nanoid(8),
           eventId: input.id,
@@ -195,14 +195,14 @@ export const eventRouter = createTRPCRouter({
   deleteRSVP: protectedProcedure
     .input(deleteEventSchema)
     .mutation(async ({ input, ctx }) => {
-      const rsvp = await ctx.db.rSVP.findFirst({
+      const rsvp = await ctx.prisma.rSVP.findFirst({
         where: {
           eventId: input.id,
           userId: ctx.session.user.id,
         },
       });
       if (rsvp) {
-        await ctx.db.rSVP.delete({
+        await ctx.prisma.rSVP.delete({
           where: {
             id: rsvp.id,
           },

--- a/server/api/router/notification.ts
+++ b/server/api/router/notification.ts
@@ -11,7 +11,7 @@ export const notificationRouter = createTRPCRouter({
     .mutation(async ({ input, ctx }) => {
       const { id } = input;
 
-      const currentNotification = await ctx.db.notification.findUnique({
+      const currentNotification = await ctx.prisma.notification.findUnique({
         where: { id },
       });
 
@@ -21,7 +21,7 @@ export const notificationRouter = createTRPCRouter({
         });
       }
 
-      const notification = await ctx.db.notification.delete({
+      const notification = await ctx.prisma.notification.delete({
         where: {
           id,
         },
@@ -30,7 +30,7 @@ export const notificationRouter = createTRPCRouter({
       return notification.id;
     }),
   deleteAll: protectedProcedure.mutation(async ({ ctx }) => {
-    const notification = await ctx.db.notification.deleteMany({
+    const notification = await ctx.prisma.notification.deleteMany({
       where: {
         userId: ctx.session.user.id,
       },
@@ -45,7 +45,7 @@ export const notificationRouter = createTRPCRouter({
 
       const limit = input?.limit ?? 50;
       const { cursor } = input;
-      const response = await ctx.db.notification.findMany({
+      const response = await ctx.prisma.notification.findMany({
         take: limit + 1,
         where: {
           userId,
@@ -87,7 +87,7 @@ export const notificationRouter = createTRPCRouter({
   getCount: protectedProcedure.query(async ({ ctx }) => {
     const userId = ctx?.session?.user?.id;
 
-    const count = await ctx.db.notification.count({
+    const count = await ctx.prisma.notification.count({
       where: {
         userId,
       },

--- a/server/api/router/profile.ts
+++ b/server/api/router/profile.ts
@@ -47,7 +47,7 @@ export const profileRouter = createTRPCRouter({
         }
       }
 
-      const profile = await ctx.db.user.update({
+      const profile = await ctx.prisma.user.update({
         where: {
           id: ctx.session.user.id,
         },
@@ -60,7 +60,7 @@ export const profileRouter = createTRPCRouter({
   updateProfilePhotoUrl: protectedProcedure
     .input(updateProfilePhotoUrlSchema)
     .mutation(async ({ input, ctx }) => {
-      const profile = await ctx.db.user.update({
+      const profile = await ctx.prisma.user.update({
         where: {
           id: ctx.session.user.id,
         },
@@ -103,7 +103,7 @@ export const profileRouter = createTRPCRouter({
     }),
   get: publicProcedure.input(getProfileSchema).query(({ ctx, input }) => {
     const { username } = input;
-    return ctx.db.user.findUnique({
+    return ctx.prisma.user.findUnique({
       where: {
         username,
       },

--- a/server/api/router/report.ts
+++ b/server/api/router/report.ts
@@ -29,7 +29,7 @@ export const reportRouter = createTRPCRouter({
         }
 
         if (type === "comment" && typeof id === "number") {
-          const comment = await ctx.db.comment.findUniqueOrThrow({
+          const comment = await ctx.prisma.comment.findUniqueOrThrow({
             where: { id },
             include: {
               user: true,
@@ -67,7 +67,7 @@ export const reportRouter = createTRPCRouter({
         }
 
         if (type === "post" && typeof id === "string") {
-          const post = await ctx.db.post.findUniqueOrThrow({
+          const post = await ctx.prisma.post.findUniqueOrThrow({
             where: { id },
             include: {
               user: true,

--- a/server/api/router/tag.ts
+++ b/server/api/router/tag.ts
@@ -5,8 +5,8 @@ import { TRPCError } from "@trpc/server";
 export const tagRouter = createTRPCRouter({
   get: publicProcedure.input(GetTagsSchema).query(async ({ ctx, input }) => {
     try {
-      const count = await ctx.db.tag.count({});
-      const response = await ctx.db.tag.findMany({
+      const count = await ctx.prisma.tag.count({});
+      const response = await ctx.prisma.tag.findMany({
         orderBy: {
           PostTag: {
             _count: "desc",

--- a/server/api/trpc.ts
+++ b/server/api/trpc.ts
@@ -13,7 +13,9 @@ import superjson from "superjson";
 import { ZodError } from "zod";
 
 import { getServerAuthSession } from "@/server/auth";
-import db from "@/server/db/client";
+
+import { db } from "@/server/db";
+import prisma from "@/server/db/client";
 
 /**
  * 1. CONTEXT
@@ -44,6 +46,8 @@ export const createInnerTRPCContext = async (opts: CreateContextOptions) => {
     session,
     headers: opts.headers,
     db,
+    // Phase out Prisma
+    prisma,
   };
 };
 

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -78,9 +78,7 @@ export const post_tagRelations = relations(post_tag, ({ one, many }) => ({
 export const tag = pgTable(
   "Tag",
   {
-    createdAt: timestamp("createdAt")
-      .notNull()
-      .default(sql`current_timestamp(3)`),
+    createdAt: timestamp("createdAt").defaultNow().notNull(),
     id: bigserial("id", { mode: "number" }).primaryKey(),
     title: varchar("title", { length: 256 }),
   },
@@ -119,12 +117,8 @@ export const post = pgTable(
     excerpt: varchar("excerpt", { length: 256 }),
     readTimeMins: integer("readTimeMins").notNull(),
     published: timestamp("published"),
-    createdAt: timestamp("createdAt")
-      .notNull()
-      .default(sql`current_timestamp(3)`),
-    updatedAt: timestamp("updatedAt").default(
-      sql`current_timestamp(3) on update current_timestamp(3)`,
-    ),
+    createdAt: timestamp("createdAt").defaultNow().notNull(),
+    updatedAt: timestamp("updatedAt").defaultNow().notNull(),
     slug: varchar("slug", { length: 256 }),
     userId: varchar("userId", { length: 256 }),
     showComments: integer("showComments").default(1),
@@ -153,12 +147,8 @@ export const user = pgTable(
     email: varchar("email", { length: 256 }),
     emailVerified: timestamp("emailVerified"),
     image: varchar("image", { length: 256 }).default("/images/person.png"),
-    createdAt: timestamp("createdAt")
-      .notNull()
-      .default(sql`current_timestamp(3)`),
-    updatedAt: timestamp("updatedAt").default(
-      sql`current_timestamp(3) on update current_timestamp(3)`,
-    ),
+    createdAt: timestamp("createdAt").defaultNow().notNull(),
+    updatedAt: timestamp("updatedAt").defaultNow().notNull(),
     bio: varchar("bio", { length: 256 }),
     location: varchar("location", { length: 256 }).default(""),
     websiteUrl: varchar("websiteUrl", { length: 256 }).default(""),
@@ -214,12 +204,8 @@ export const comment = pgTable(
   {
     id: bigserial("id", { mode: "number" }).primaryKey(),
     body: varchar("body", { length: 256 }),
-    createdAt: timestamp("createdAt")
-      .notNull()
-      .default(sql`current_timestamp(3)`),
-    updatedAt: timestamp("updatedAt").default(
-      sql`current_timestamp(3) on update current_timestamp(3)`,
-    ),
+    createdAt: timestamp("createdAt").defaultNow().notNull(),
+    updatedAt: timestamp("updatedAt").defaultNow().notNull(),
     postId: varchar("postId", { length: 256 }),
     userId: varchar("userId", { length: 256 }),
     parentId: integer("parentId"),
@@ -246,9 +232,7 @@ export const like = pgTable(
   "Like",
   {
     id: bigserial("id", { mode: "number" }).primaryKey(),
-    createdAt: timestamp("createdAt")
-      .notNull()
-      .default(sql`current_timestamp(3)`),
+    createdAt: timestamp("createdAt").defaultNow().notNull(),
     userId: varchar("userId", { length: 256 }),
     postId: varchar("postId", { length: 256 }),
     commentId: integer("commentId"),
@@ -271,12 +255,8 @@ export const banned_users = pgTable(
   "BannedUsers",
   {
     id: bigserial("id", { mode: "number" }).primaryKey(),
-    createdAt: timestamp("createdAt")
-      .notNull()
-      .default(sql`current_timestamp(3)`),
-    updatedAt: timestamp("updatedAt").default(
-      sql`current_timestamp(3) on update current_timestamp(3)`,
-    ),
+    createdAt: timestamp("createdAt").defaultNow().notNull(),
+    updatedAt: timestamp("updatedAt").defaultNow().notNull(),
     userId: varchar("userId", { length: 256 }),
     bannedById: varchar("bannedById", { length: 256 }),
     note: varchar("note", { length: 256 }),
@@ -326,9 +306,7 @@ export const membership = pgTable(
     communityId: varchar("communityId", { length: 256 }),
     userId: varchar("userId", { length: 256 }),
     isEventOrganiser: integer("isEventOrganiser").default(0),
-    createdAt: timestamp("createdAt")
-      .notNull()
-      .default(sql`current_timestamp(3)`),
+    createdAt: timestamp("createdAt").defaultNow().notNull(),
   },
   (t) => {
     return {};
@@ -349,9 +327,7 @@ export const r_s_v_p = pgTable(
     id: varchar("id", { length: 256 }),
     eventId: varchar("eventId", { length: 256 }),
     userId: varchar("userId", { length: 256 }),
-    createdAt: timestamp("createdAt")
-      .notNull()
-      .default(sql`current_timestamp(3)`),
+    createdAt: timestamp("createdAt").defaultNow().notNull(),
   },
   (t) => {
     return {};
@@ -367,12 +343,8 @@ export const flagged = pgTable(
   "Flagged",
   {
     id: bigserial("id", { mode: "number" }).primaryKey(),
-    createdAt: timestamp("createdAt")
-      .notNull()
-      .default(sql`current_timestamp(3)`),
-    updatedAt: timestamp("updatedAt").default(
-      sql`current_timestamp(3) on update current_timestamp(3)`,
-    ),
+    createdAt: timestamp("createdAt").defaultNow().notNull(),
+    updatedAt: timestamp("updatedAt").defaultNow().notNull(),
     userId: varchar("userId", { length: 256 }),
     notifierId: varchar("notifierId", { length: 256 }),
     note: varchar("note", { length: 256 }),
@@ -398,12 +370,8 @@ export const notification = pgTable(
   "Notification",
   {
     id: bigserial("id", { mode: "number" }).primaryKey(),
-    createdAt: timestamp("createdAt")
-      .notNull()
-      .default(sql`current_timestamp(3)`),
-    updatedAt: timestamp("updatedAt").default(
-      sql`current_timestamp(3) on update current_timestamp(3)`,
-    ),
+    createdAt: timestamp("createdAt").defaultNow().notNull(),
+    updatedAt: timestamp("updatedAt").defaultNow().notNull(),
     type: integer("type").notNull(),
     userId: varchar("userId", { length: 256 }),
     postId: varchar("postId", { length: 256 }),

--- a/server/trpc/trpc.ts
+++ b/server/trpc/trpc.ts
@@ -3,7 +3,9 @@ import { type NextRequest } from "next/server";
 import superjson from "superjson";
 import { ZodError } from "zod";
 import { getServerAuthSession } from "@/server/auth";
-import db from "@/server/db/client";
+import prisma from "@/server/db/client";
+
+import { db } from "@/server/db";
 
 /**
  * 1. CONTEXT
@@ -34,6 +36,8 @@ export const createInnerTRPCContext = async (opts: CreateContextOptions) => {
     session,
     headers: opts.headers,
     db,
+    // Phase out Prisma
+    prisma,
   };
 };
 


### PR DESCRIPTION
And migrate create posts to Drizzle as an Example

# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

## Pull Request details

- Expose Drizzle to tRPC context
- Rename Prisma client to `prisma` on `.ctx` so it's clear what to migrate from
- Added an example of a migration with the `create` endpoint

## Any Breaking changes

- None



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the data access layer across various routers (admin, comment, community, event, notification, post, profile, report, tag) and server configurations to use Prisma ORM (`ctx.prisma`) instead of the custom database context (`ctx.db`), enhancing database operations and interactions.
- **Chores**
	- Improved consistency in database schema definitions for `createdAt` and `updatedAt` fields, ensuring uniformity and reliability in timestamp management across entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->