### PR TITLE
split name field into first and last name

### DIFF
--- a/app/(app)/settings/_client.tsx
+++ b/app/(app)/settings/_client.tsx
@@ -20,6 +20,8 @@ function classNames(...classes: string[]) {
 type User = Prisma.UserGetPayload<{
   select: {
     name: true;
+    firstName: true;
+    surname: true;
     username: true;
     bio: true;
     location: true;

--- a/app/(app)/settings/_client.tsx
+++ b/app/(app)/settings/_client.tsx
@@ -45,7 +45,12 @@ const Settings = ({ profile }: { profile: User }) => {
     formState: { errors },
   } = useForm<saveSettingsInput>({
     resolver: zodResolver(saveSettingsSchema),
-    defaultValues: { ...profile, username: profile.username || "" },
+    defaultValues: {
+      ...profile,
+      username: profile.username || "",
+      firstName: profile.firstName || "",
+      surname: profile.surname || "",
+    },
   });
 
   const bio = watch("bio");
@@ -152,16 +157,30 @@ const Settings = ({ profile }: { profile: User }) => {
                   <div className="mt-6 flex flex-col lg:flex-row">
                     <div className="flex-grow space-y-6">
                       <div>
-                        <label htmlFor="name">Full Name</label>
+                        <label htmlFor="firstName">First Name</label>
                         <input
                           type="text"
-                          {...register("name")}
-                          id="name"
+                          {...register("firstName")}
+                          id="firstName"
                           autoComplete="given-name"
                         />
-                        {errors.name && (
+                        {errors.firstName && (
                           <p className="mt-1 text-sm text-red-600">
-                            {`${errors.name.message || "Required"}`}
+                            {`${errors.firstName.message || "Required"}`}
+                          </p>
+                        )}
+                      </div>
+                      <div>
+                        <label htmlFor="surname">Surname</label>
+                        <input
+                          type="text"
+                          {...register("surname")}
+                          id="surname"
+                          autoComplete="family-name"
+                        />
+                        {errors.surname && (
+                          <p className="mt-1 text-sm text-red-600">
+                            {`${errors.surname.message || "Required"}`}
                           </p>
                         )}
                       </div>

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -17,6 +17,8 @@ export default async function Page() {
 
   const select = {
     name: true,
+    firstName: true,
+    surname: true,
     username: true,
     bio: true,
     location: true,
@@ -30,12 +32,33 @@ export default async function Page() {
     redirect("/get-started");
   }
 
-  const user = await prisma.user.findUnique({
+  let user = await prisma.user.findUnique({
     where: {
       id: session.user.id,
     },
     select,
   });
+
+  if (user && user.name && !user?.firstName && !user?.surname) {
+    const trimmedName = user.name.trim();
+    const nameParts = trimmedName.split(" ");
+
+    if (nameParts.length > 1) {
+      const surname = nameParts.pop();
+      const firstName = nameParts.join(" ");
+
+      user = await prisma.user.update({
+        where: {
+          id: session.user.id,
+        },
+        data: {
+          firstName,
+          surname,
+        },
+        select,
+      });
+    }
+  }
 
   if (!user?.username) {
     const nanoid = customAlphabet("1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ", 3);

--- a/schema/profile.ts
+++ b/schema/profile.ts
@@ -1,7 +1,16 @@
 import z from "zod";
 
 export const saveSettingsSchema = z.object({
-  name: z.string().min(1).max(50),
+  firstName: z
+    .string()
+    .trim()
+    .min(2, "Min name length is 2 characters.")
+    .max(50, "Max name length is 50 characters."),
+  surname: z
+    .string()
+    .trim()
+    .min(2, "Min name length is 2 characters.")
+    .max(50, "Max name length is 50 characters."),
   bio: z.string().max(200).optional(),
   username: z
     .string()


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

## Pull Request details

- On loading the settings page check if there is a name field on the user object, but no surname or First Name 
- split the name into first and last and update the Prisma model.
- If there is no space In the string then dont do anything.

- Should be noted this will only work for new users logging in for the first time, or existing users who click on the settings page.

## Any Breaking changes
no

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced user profile settings to include `firstName` and `surname` fields. If only a full name is provided, it will automatically split this into first and surname for convenience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->