### PR TITLE
migrate to drizzle profile routes

### DIFF
--- a/server/api/router/profile.ts
+++ b/server/api/router/profile.ts
@@ -55,6 +55,12 @@ export const profileRouter = createTRPCRouter({
         .where(eq(user.id, ctx.session.user.id))
         .returning();
 
+      if (!profile) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Profile not found or update failed",
+        });
+      }
       return profile;
     }),
   updateProfilePhotoUrl: protectedProcedure
@@ -66,6 +72,12 @@ export const profileRouter = createTRPCRouter({
         .where(eq(user.id, ctx.session.user.id))
         .returning();
 
+      if (!profile) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Profile not found or update failed",
+        });
+      }
       return profile;
     }),
   getUploadUrl: protectedProcedure
@@ -105,6 +117,13 @@ export const profileRouter = createTRPCRouter({
       .select()
       .from(user)
       .where(eq(user.username, username));
+
+    if (!profile) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Profile not found",
+      });
+    }
     return profile;
   }),
 });

--- a/server/api/router/profile.ts
+++ b/server/api/router/profile.ts
@@ -1,3 +1,4 @@
+import { user } from "@/server/db/schema";
 import {
   saveSettingsSchema,
   getProfileSchema,
@@ -14,6 +15,7 @@ import {
 } from "@/server/lib/newsletter";
 import { TRPCError } from "@trpc/server";
 import { nanoid } from "nanoid";
+import { eq } from "drizzle-orm";
 
 export const profileRouter = createTRPCRouter({
   edit: protectedProcedure
@@ -47,27 +49,23 @@ export const profileRouter = createTRPCRouter({
         }
       }
 
-      const profile = await ctx.prisma.user.update({
-        where: {
-          id: ctx.session.user.id,
-        },
-        data: {
-          ...input,
-        },
-      });
+      const [profile] = await ctx.db
+        .update(user)
+        .set({ ...input })
+        .where(eq(user.id, ctx.session.user.id))
+        .returning();
+
       return profile;
     }),
   updateProfilePhotoUrl: protectedProcedure
     .input(updateProfilePhotoUrlSchema)
     .mutation(async ({ input, ctx }) => {
-      const profile = await ctx.prisma.user.update({
-        where: {
-          id: ctx.session.user.id,
-        },
-        data: {
-          image: `${input.url}?id=${nanoid(3)}`,
-        },
-      });
+      const [profile] = await ctx.db
+        .update(user)
+        .set({ image: `${input.url}?id=${nanoid(3)}` })
+        .where(eq(user.id, ctx.session.user.id))
+        .returning();
+
       return profile;
     }),
   getUploadUrl: protectedProcedure
@@ -101,12 +99,12 @@ export const profileRouter = createTRPCRouter({
 
       return response;
     }),
-  get: publicProcedure.input(getProfileSchema).query(({ ctx, input }) => {
+  get: publicProcedure.input(getProfileSchema).query(async ({ ctx, input }) => {
     const { username } = input;
-    return ctx.prisma.user.findUnique({
-      where: {
-        username,
-      },
-    });
+    const [profile] = await ctx.db
+      .select()
+      .from(user)
+      .where(eq(user.username, username));
+    return profile;
   }),
 });


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

I've refactored the following profile.ts routes: edit, updateProfilePhotoUrl, and get from Prisma to Drizzle. While I wasn't able to conduct testing on these routes in the development environment, I used JSON.stringify to compare the returned objects and believe they are functioning correctly.

There's a peculiarity with the get route: it queries based on the username rather than the user id. 
Moreover, upon inspection, it seems that this route isn't being called anywhere in the codebase??

## Any Breaking changes

- Hopefully not, but I would still like to test each route



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced user profile and photo URL updating process for better performance and reliability.
	- Improved querying of user profiles for more efficient data retrieval.
	- Replaced `prisma` with `ctx.db` for updating user profile and photo URL.
	- Changed the logic for updating profile and photo URL using `drizzle-orm`.
	- Modified the `get` method to query user profile using `ctx.db` and `drizzle-orm`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->