### PR TITLE
chore: migrated create comment function to drizzle

### DIFF
--- a/server/api/router/comment.ts
+++ b/server/api/router/comment.ts
@@ -33,7 +33,6 @@ export const commentRouter = createTRPCRouter({
           postId,
           body,
           parentId,
-          updatedAt: new Date(),
         })
         .returning();
 
@@ -50,7 +49,6 @@ export const commentRouter = createTRPCRouter({
             postId,
             userId: commentData.userId,
             commentId: createdComment.id,
-            updatedAt: new Date(),
           });
         }
       }
@@ -62,7 +60,6 @@ export const commentRouter = createTRPCRouter({
           postId,
           userId: postOwnerId,
           commentId: createdComment.id,
-          updatedAt: new Date(),
         });
       }
 


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

## Pull Request details

- Pretty much a lift and shift. Nothing to complex

## Any Breaking changes

- Potentially if we dont migrate the DB to match the Drizzle schema before we deploy this
- Drizzle schema has updatedAt as defaultNow() but it seems prisma had some type of @updatedAt which was doing this. Therefore theres a nonNull constraint on updatedAt from the prisma schema and a defaultNow() from the drizzle schema. To overcome this I was able to drop the DB and recreate it from the drizzle schema. We may not be able to do this in Prod

## Associated Screenshots
<img width="914" alt="Showing the implemented comments" src="https://github.com/codu-code/codu/assets/46611809/29fee3df-e569-476a-8adf-8080ba8d7d34">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced comment and notification handling for improved performance and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->