### PR TITLE
fix: adding timezone to post.published initial schema migration

### DIFF
--- a/drizzle/0000_initial_schema.sql
+++ b/drizzle/0000_initial_schema.sql
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS "Post" (
 	"body" text NOT NULL,
 	"excerpt" varchar(156) DEFAULT ''::character varying NOT NULL,
 	"readTimeMins" integer NOT NULL,
-	"published" timestamp(3),
+	"published" timestamp(3) with time zone,
 	"createdAt" timestamp(3) with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
 	"updatedAt" timestamp(3) with time zone NOT NULL,
 	"slug" text NOT NULL,


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

## Pull Request details

- Somehow missed one timestamp in initial schema

## Any Breaking changes

- None

## Associated Screenshots

- None
