### PR TITLE
Removing duplicate posts from published function

### DIFF
--- a/server/api/router/post.ts
+++ b/server/api/router/post.ts
@@ -348,6 +348,7 @@ export const postRouter = createTRPCRouter({
             cursor ? paginationMapping[sort].cursor : undefined,
           ),
         )
+        .groupBy(post.id, bookmarked.id, user.id)
         .limit(limit + 1)
         .orderBy(paginationMapping[sort].orderBy);
 


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

![Codu Logo](https://raw.githubusercontent.com/codu-code/codu/develop/public/images/codu-gradient.png)

## Pull Request details

- Published function is returning duplicates currently in Prod
- This is because of the leftJoin with post_tags. Posts with multiple tags are being returned multiple times.
- Grouping by id removes these duplicates

## Any Breaking changes

- None

## Associated Screenshots

Before
<img width="1723" alt="Before image showing all the duplicates" src="https://github.com/codu-code/codu/assets/46611809/4f9961de-e601-47b8-9089-1f834893e37f">

After
<img width="1723" alt="Showing after without duplicates" src="https://github.com/codu-code/codu/assets/46611809/7cb4bc07-28a5-499d-abc1-3412af770cfc">

Both with same DB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the grouping logic in query results for enhanced data organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->