### PR TITLE
Replace Verbose Placeholder Title

### DIFF
--- a/components/editor/editor/extensions/index.tsx
+++ b/components/editor/editor/extensions/index.tsx
@@ -184,7 +184,7 @@ export const TiptapExtensions = [
   Placeholder.configure({
     placeholder: ({ node }) => {
       if (node.type.name === "heading" && node.attrs.level == 1) {
-        return "Add a title to your post here!";
+        return "Title";
       }
 
       return "type / to see a list of formatting features";


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

Fixes #1038 

## Pull Request details

This pull request replaces the verbose placeholder title in the alpha editor with a more concise placeholder: "Title." This change aims to reduce verbosity and allow for more efficient use of space in the editor.

Changes Made:
- Updated the placeholder title in the alpha editor.

## Any Breaking changes

None

## Associated Screenshots

![codu-after](https://github.com/user-attachments/assets/bc2ca51d-36c3-48e9-b061-dbf0fc5bed4f)
![codu-before](https://github.com/user-attachments/assets/fdf1b194-cb5d-4105-bb44-8511928be44f)

