### PR TITLE
Removed Sign up today banner when the user is logged in

### DIFF
--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -17,26 +17,28 @@ const Home = async () => {
     <>
       <div>
         <Hero />
-        <section className="bg-white px-2 dark:bg-neutral-300" id="cta">
-          <div className="mx-auto py-20 sm:max-w-2xl sm:py-32 lg:max-w-5xl">
-            <h2 className="max-w-[660px] text-center text-2xl font-semibold tracking-tight text-neutral-900 dark:text-gray-900 sm:text-4xl md:text-left">
-              <span className="font-extrabold">Sign up today</span> to become a
-              writer and get a <span className="font-extrabold">free</span>{" "}
-              invite to our Discord community.
-            </h2>
-            <div className="mt-8 flex items-center justify-center gap-x-6 md:justify-start">
-              <Link href="/get-started" className="primary-button">
-                Get started
-              </Link>
-              <Link
-                href="/articles/explore-the-benefits-of-being-a-part-of-cod-ety1wehv"
-                className="font-semibold leading-6 text-neutral-900 dark:text-gray-900"
-              >
-                Learn more <span aria-hidden="true">→</span>
-              </Link>
+        {session == null && (
+          <section className="bg-white px-2 dark:bg-neutral-300" id="cta">
+            <div className="mx-auto py-20 sm:max-w-2xl sm:py-32 lg:max-w-5xl">
+              <h2 className="max-w-[660px] text-center text-2xl font-semibold tracking-tight text-neutral-900 dark:text-gray-900 sm:text-4xl md:text-left">
+                <span className="font-extrabold">Sign up today</span> to become a
+                writer and get a <span className="font-extrabold">free</span>{" "}
+                invite to our Discord community.
+              </h2>
+              <div className="mt-8 flex items-center justify-center gap-x-6 md:justify-start">
+                <Link href="/get-started" className="primary-button">
+                  Get started
+                </Link>
+                <Link
+                  href="/articles/explore-the-benefits-of-being-a-part-of-cod-ety1wehv"
+                  className="font-semibold leading-6 text-neutral-900 dark:text-gray-900"
+                >
+                  Learn more <span aria-hidden="true">→</span>
+                </Link>
+              </div>
             </div>
-          </div>
-        </section>
+          </section>
+        )}
       </div>
 
       <div className="mx-2">

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -21,8 +21,8 @@ const Home = async () => {
           <section className="bg-white px-2 dark:bg-neutral-300" id="cta">
             <div className="mx-auto py-20 sm:max-w-2xl sm:py-32 lg:max-w-5xl">
               <h2 className="max-w-[660px] text-center text-2xl font-semibold tracking-tight text-neutral-900 dark:text-gray-900 sm:text-4xl md:text-left">
-                <span className="font-extrabold">Sign up today</span> to become a
-                writer and get a <span className="font-extrabold">free</span>{" "}
+                <span className="font-extrabold">Sign up today</span> to become
+                a writer and get a <span className="font-extrabold">free</span>{" "}
                 invite to our Discord community.
               </h2>
               <div className="mt-8 flex items-center justify-center gap-x-6 md:justify-start">


### PR DESCRIPTION
# ✨ Codu Pull Request 💻
Fixes #1091 

## Pull Request details

- session object is populated when the user is logged in
- When the user is not logged in, session object is null
- Added a null check before rendering the **Sign up today** banner

## Any Breaking changes
None

## Associated Screenshots
**Before logging in:**
![screencapture-localhost-3000-2024-10-08-22_28_28](https://github.com/user-attachments/assets/b2f3caf8-fa56-4da5-b54d-004c908ce438)

**After Signing in:**
![screencapture-localhost-3000-2024-10-08-22_29_10](https://github.com/user-attachments/assets/5f895302-41ec-455a-9c39-5619796326bf)

## Note to Reviewers
Made all the changes as per the Issue #1091 
If there is anything else to be done as part of this please let me know 

