### PR TITLE
[fix] Post Sorting and Timestamp Display in Your Posts Section

### DIFF
--- a/app/(app)/my-posts/_client.tsx
+++ b/app/(app)/my-posts/_client.tsx
@@ -24,6 +24,17 @@ function classNames(...classes: string[]) {
   return classes.filter(Boolean).join(" ");
 }
 
+const renderDate = (label: string, date: string | Date) => (
+  <small>
+    {label} {new Date(date).toLocaleDateString()} at{" "}
+    {new Date(date).toLocaleTimeString(navigator.language, {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    })}
+  </small>
+);
+
 const MyPosts = () => {
   const searchParams = useSearchParams();
 
@@ -113,7 +124,15 @@ const MyPosts = () => {
 
           {selectedTabData.status === "success" &&
             selectedTabData.data?.map(
-              ({ id, title, excerpt, readTimeMins, slug, published, updatedAt }) => {
+              ({
+                id,
+                title,
+                excerpt,
+                readTimeMins,
+                slug,
+                published,
+                updatedAt,
+              }) => {
                 const postStatus = published
                   ? getPostStatus(new Date(published))
                   : PostStatus.DRAFT;
@@ -140,58 +159,24 @@ const MyPosts = () => {
                     <div className="flex items-center">
                       <div className="flex-grow">
                         {published && postStatus === PostStatus.SCHEDULED ? (
-                          <small>
-                            Scheduled to publish on{" "}
-                            {new Date(published).toLocaleDateString()} at{" "}
-                            {new Date(published).toLocaleTimeString(
-                              navigator.language,
-                              {
-                                hour: "2-digit",
-                                minute: "2-digit",
-                                hour12: false,
-                              },
-                            )}
-                          </small>
+                          <>
+                            {renderDate("Scheduled to publish on ", published)}
+                          </>
                         ) : published && postStatus === PostStatus.PUBLISHED ? (
-                          <small>
+                          <>
                             {/*If updatedAt is greater than published by more than on minutes show updated at else show published 
                               as on updating published updatedAt is automatically updated and is greater than published*/}
-                            {(new Date(updatedAt).getTime() - new Date(published).getTime()) >= 60000 ? (
-                              <>
-                                {"Last updated on "}
-                                {new Date(updatedAt).toLocaleDateString()} at{" "}
-                                {new Date(updatedAt).toLocaleTimeString(navigator.language, {
-                                  hour: "2-digit",
-                                  minute: "2-digit",
-                                  hour12: false,
-                                })}
-                              </>
+                            {new Date(updatedAt).getTime() -
+                              new Date(published).getTime() >=
+                            60000 ? (
+                              <>{renderDate("Last updated on ", updatedAt)}</>
                             ) : (
-                              <>
-                                {"Published on "}
-                                {new Date(published).toLocaleDateString()} at{" "}
-                                {new Date(published).toLocaleTimeString(navigator.language, {
-                                  hour: "2-digit",
-                                  minute: "2-digit",
-                                  hour12: false,
-                                })}
-                              </>
+                              <>{renderDate("Published on ", published)}</>
                             )}
-                          </small>
-                        ): postStatus === PostStatus.DRAFT ? (
-                        <small>
-                          Last Updated on {" "}
-                          {new Date(updatedAt).toLocaleDateString()} at{" "}
-                          {new Date(updatedAt).toLocaleTimeString(
-                            navigator.language,
-                            {
-                              hour: "2-digit",
-                              minute: "2-digit",
-                              hour12: false,
-                            },
-                          )}
-                        </small>
-                      ): null}
+                          </>
+                        ) : postStatus === PostStatus.DRAFT ? (
+                          <>{renderDate("Last updated on ", updatedAt)}</>
+                        ) : null}
                       </div>
 
                       <Menu

--- a/app/(app)/my-posts/_client.tsx
+++ b/app/(app)/my-posts/_client.tsx
@@ -113,7 +113,7 @@ const MyPosts = () => {
 
           {selectedTabData.status === "success" &&
             selectedTabData.data?.map(
-              ({ id, title, excerpt, readTimeMins, slug, published }) => {
+              ({ id, title, excerpt, readTimeMins, slug, published, updatedAt }) => {
                 const postStatus = published
                   ? getPostStatus(new Date(published))
                   : PostStatus.DRAFT;
@@ -154,18 +154,44 @@ const MyPosts = () => {
                           </small>
                         ) : published && postStatus === PostStatus.PUBLISHED ? (
                           <small>
-                            Published on{" "}
-                            {new Date(published).toLocaleDateString()} at{" "}
-                            {new Date(published).toLocaleTimeString(
-                              navigator.language,
-                              {
-                                hour: "2-digit",
-                                minute: "2-digit",
-                                hour12: false,
-                              },
+                            {/*If updatedAt is greater than published by more than on minutes show updated at else show published 
+                              as on updating published updatedAt is automatically updated and is greater than published*/}
+                            {(new Date(updatedAt).getTime() - new Date(published).getTime()) >= 60000 ? (
+                              <>
+                                {"Last updated on "}
+                                {new Date(updatedAt).toLocaleDateString()} at{" "}
+                                {new Date(updatedAt).toLocaleTimeString(navigator.language, {
+                                  hour: "2-digit",
+                                  minute: "2-digit",
+                                  hour12: false,
+                                })}
+                              </>
+                            ) : (
+                              <>
+                                {"Published on "}
+                                {new Date(published).toLocaleDateString()} at{" "}
+                                {new Date(published).toLocaleTimeString(navigator.language, {
+                                  hour: "2-digit",
+                                  minute: "2-digit",
+                                  hour12: false,
+                                })}
+                              </>
                             )}
                           </small>
-                        ) : null}
+                        ): postStatus === PostStatus.DRAFT ? (
+                        <small>
+                          Last Updated on {" "}
+                          {new Date(updatedAt).toLocaleDateString()} at{" "}
+                          {new Date(updatedAt).toLocaleTimeString(
+                            navigator.language,
+                            {
+                              hour: "2-digit",
+                              minute: "2-digit",
+                              hour12: false,
+                            },
+                          )}
+                        </small>
+                      ): null}
                       </div>
 
                       <Menu

--- a/server/api/router/post.ts
+++ b/server/api/router/post.ts
@@ -395,7 +395,9 @@ export const postRouter = createTRPCRouter({
           lte(posts.published, new Date().toISOString()),
           eq(posts.userId, ctx?.session?.user?.id),
         ),
-      orderBy: (posts, { desc }) => [desc(posts.published)],
+      orderBy: (posts, { desc, sql }) => [
+        desc(sql`GREATEST(${posts.updatedAt}, ${posts.published})`),
+      ],
     });
   }),
   myScheduled: protectedProcedure.query(async ({ ctx }) => {
@@ -413,6 +415,7 @@ export const postRouter = createTRPCRouter({
     return ctx.db.query.post.findMany({
       where: (posts, { eq }) =>
         and(eq(posts.userId, ctx.session.user.id), isNull(posts.published)),
+      orderBy: (posts, { desc }) => [desc(posts.updatedAt)],
     });
   }),
   editDraft: protectedProcedure


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

Fixes #(1088)
<!-- for example `Fixes #1012` -->

## Pull Request details

- Added support for sorted Drat posts

- Added support for sorted Published posts

In published posts section as the post is published update post is done so updatedAt is set to slightly greater time than published so use 1 minute time difference to distinguish between a published post and a post that published but updated later

## Any Breaking changes
NONE

## Associated Screenshots

![Screenshot from 2024-10-08 23-00-52](https://github.com/user-attachments/assets/c2da38ea-37cf-40f6-91f5-1c066cb9c160)
![Screenshot from 2024-10-08 23-00-41](https://github.com/user-attachments/assets/e284e232-1000-4a06-9cc8-fd43f586b961)
![Screenshot from 2024-10-08 23-00-25](https://github.com/user-attachments/assets/164cd4f9-a885-4691-a57d-2efadb3d6a9e)

