### PR TITLE
style update add z-20 tailwind class to mobile-nav component

### DIFF
--- a/components/Nav/MobileNav.tsx
+++ b/components/Nav/MobileNav.tsx
@@ -25,7 +25,7 @@ const MobileNav: FunctionComponent<MobileNavProps> = ({
   close,
 }) => {
   return (
-    <div className="absolute z-10 w-screen bg-neutral-100 dark:bg-black">
+    <div className="absolute z-20 w-screen bg-neutral-100 dark:bg-black">
       <DisclosurePanel className="relative border-b border-neutral-400 dark:border-neutral-600 md:hidden">
         <div className="space-y-1 px-2 pb-3 pt-2">
           {navigation.map((item) => (


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

Fixes #(issue)
#1123 



## Pull Request details
Increased the z-index to be above the Codú logo 


- INFO ABOUT YOUR PULL REQUEST GOES HERE (Please be as descriptive as possible) 🤜
- Use bullet points to make it easy to read.

## Any Breaking changes
I REALLY HOPE NOT (really hope not) 

## Associated Screenshots
Before: 

![Open nav bar with incorrect z-index with Codú written on top of the extended nav](https://github.com/user-attachments/assets/392fca9e-bf7d-4218-ae3d-f0d6da3c39be)


After:
![Open nav bar with correct z-index with the nav appearing above Codú logo](https://github.com/user-attachments/assets/e349883a-d2cb-4d9b-9c82-95e2481cd15e)



