### PR TITLE
 Feature/ Add series to link related articles

### DIFF
--- a/app/(app)/create/[[...paramsArr]]/_client.tsx
+++ b/app/(app)/create/[[...paramsArr]]/_client.tsx
@@ -162,8 +162,6 @@ const Create = () => {
 
   const { mutate: seriesUpdate, status: seriesStatus } = api.series.update.useMutation({
     onError(error) {
-      // TODO: Add error messages from field validations
-      console.log("Error updating settings: ", error);
       toast.error("Error auto-saving");
       Sentry.captureException(error);
     }
@@ -236,11 +234,19 @@ const Create = () => {
     if (!formData.id) {
       await create({ ...formData });
     } else {
-      await Promise.all([
-        save({ ...formData, id: postId }),
-        seriesUpdate({postId, seriesName: formData.seriesName})
-      ]);
-      toast.success("Saved");
+      try {
+        await save({ ...formData, id: postId });
+      } catch (error) {
+        toast.error("Error saving post.");
+        Sentry.captureException(error);
+      }
+      try {
+        await seriesUpdate({ postId, seriesName: formData.seriesName });
+        toast.success("Saved");
+      } catch (error) {
+        toast.error("Error updating series.");
+        Sentry.captureException(error);
+      }
       setSavedTime(
         new Date().toLocaleString(undefined, {
           dateStyle: "medium",
@@ -556,7 +562,7 @@ const Create = () => {
                                 Share this link with others to preview your
                                 draft. Anyone with the link can view your draft.
                               </p>
-                              
+
                               <label htmlFor="seriesName">
                                 Series Name
                               </label>

--- a/app/(app)/create/[[...paramsArr]]/_client.tsx
+++ b/app/(app)/create/[[...paramsArr]]/_client.tsx
@@ -162,7 +162,7 @@ const Create = () => {
 
   const { mutate: seriesUpdate, status: seriesStatus } = api.series.update.useMutation({
     onError(error) {
-      toast.error("Error auto-saving");
+      toast.error("Error updating series");
       Sentry.captureException(error);
     }
   });
@@ -234,19 +234,30 @@ const Create = () => {
     if (!formData.id) {
       await create({ ...formData });
     } else {
+      let saveSuccess = false;
       try {
         await save({ ...formData, id: postId });
+        saveSuccess = true;
       } catch (error) {
         toast.error("Error saving post.");
         Sentry.captureException(error);
       }
+
+      let seriesUpdateSuccess = false;
       try {
-        await seriesUpdate({ postId, seriesName: formData.seriesName });
-        toast.success("Saved");
+        if(formData?.seriesName){
+          await seriesUpdate({ postId, seriesName: formData.seriesName });
+        }
+        seriesUpdateSuccess = true;
       } catch (error) {
         toast.error("Error updating series.");
         Sentry.captureException(error);
       }
+
+      if(saveSuccess && seriesUpdateSuccess){
+        toast.success("Saved");
+      }
+
       setSavedTime(
         new Date().toLocaleString(undefined, {
           dateStyle: "medium",

--- a/drizzle/0011_add_series_update_post.sql
+++ b/drizzle/0011_add_series_update_post.sql
@@ -1,0 +1,12 @@
+-- Create Series table
+CREATE TABLE IF NOT EXISTS "Series" (
+  "id" SERIAL PRIMARY KEY,
+  "title" TEXT NOT NULL,
+  "description" TEXT,
+  "userId" TEXT NOT NULL,
+  "createdAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL
+);
+-- Update Post table to add seriesId column
+ALTER TABLE "Post"
+ADD COLUMN "seriesId" INTEGER

--- a/drizzle/0011_add_series_update_post.sql
+++ b/drizzle/0011_add_series_update_post.sql
@@ -10,3 +10,7 @@ CREATE TABLE IF NOT EXISTS "Series" (
 -- Update Post table to add seriesId column
 ALTER TABLE "Post"
 ADD COLUMN "seriesId" INTEGER
+ADD CONSTRAINT fk_post_series
+    FOREIGN KEY ("seriesId")
+    REFERENCES "Series" ("id")
+    ON DELETE SET NULL;

--- a/schema/post.ts
+++ b/schema/post.ts
@@ -25,6 +25,7 @@ export const SavePostSchema = z.object({
   canonicalUrl: z.optional(z.string().trim().url()),
   tags: z.string().array().max(5).optional(),
   published: z.string().datetime().optional(),
+  seriesName: z.string().trim().optional()
 });
 
 export const PublishPostSchema = z.object({
@@ -50,6 +51,7 @@ export const ConfirmPostSchema = z.object({
     .optional(),
   canonicalUrl: z.string().trim().url().optional(),
   tags: z.string().array().max(5).optional(),
+  seriesName: z.string().trim().optional()
 });
 
 export const DeletePostSchema = z.object({

--- a/schema/series.ts
+++ b/schema/series.ts
@@ -1,0 +1,6 @@
+import z from "zod";
+
+export const UpdateSeriesSchema = z.object({
+    postId: z.string(),
+    seriesName: z.string().trim().optional()
+});

--- a/server/api/router/index.ts
+++ b/server/api/router/index.ts
@@ -8,6 +8,8 @@ import { adminRouter } from "./admin";
 import { reportRouter } from "./report";
 import { tagRouter } from "./tag";
 
+import { seriesRouter } from "./series";
+
 export const appRouter = createTRPCRouter({
   post: postRouter,
   profile: profileRouter,
@@ -16,6 +18,7 @@ export const appRouter = createTRPCRouter({
   admin: adminRouter,
   report: reportRouter,
   tag: tagRouter,
+  series: seriesRouter
 });
 
 // export type definition of API

--- a/server/api/router/series.ts
+++ b/server/api/router/series.ts
@@ -1,0 +1,114 @@
+import { TRPCError } from "@trpc/server";
+import { createTRPCRouter, protectedProcedure } from "../trpc";
+import { series, post } from "@/server/db/schema";
+import { UpdateSeriesSchema } from "@/schema/series";
+import {eq} from "drizzle-orm";
+export const seriesRouter = createTRPCRouter({
+    update: protectedProcedure
+        .input(UpdateSeriesSchema)
+        .mutation(async ({input, ctx}) => {
+            const {postId, seriesName} = input;
+            console.group("series Name: ", seriesName);
+            const currentPost = await ctx.db.query.post.findFirst({
+                columns: {
+                  id: true,
+                  seriesId: true,
+                  userId: true
+                },
+                with: {
+                  series: {
+                    columns: {
+                      id: true,
+                      title: true
+                    },
+                  },
+                },
+                where: (post, { eq }) => eq(post.id, postId),
+              });
+            if (currentPost?.userId !== ctx.session.user.id) {
+                throw new TRPCError({
+                  code: "FORBIDDEN",
+                });
+            }
+            const createNewSeries = async (seriesTitle: string) => {
+              // check if a series with that name already exists
+              // or else create a new one
+              let seriesId : number;
+              const currSeries = await ctx.db.query.series.findFirst({
+                columns: {
+                  id: true
+                },
+                where: (series, { eq }) => eq(series.title, seriesTitle),
+              })
+              if(!currSeries){
+                const [newSeries] = await ctx.db.insert(series).values({
+                  title: seriesTitle, 
+                  userId: ctx.session.user.id,
+                  updatedAt: new Date()  
+                }).returning();
+                
+                seriesId = newSeries.id;
+              }
+              else{
+                seriesId = currSeries.id;
+              }
+                // update that series id in the current post
+                await ctx.db
+                .update(post)
+                .set({
+                    seriesId: seriesId
+                })
+                .where(eq(post.id, currentPost.id));
+            }
+            const unlinkSeries = async (seriesId: number) => {
+              // Check if the user has added a another post with the same series id previously
+              const anotherPostInThisSeries = await ctx.db.query.post.findFirst({
+                where: (post, { eq, and, ne }) => 
+                    and (
+                      ne(post.id, currentPost.id),
+                      eq(post.seriesId, currentPost.seriesId!)
+                    )
+              })
+              // if another post with the same seriesId is present, then do nothing
+              // else remove the series from the series table
+              if(!anotherPostInThisSeries){
+                  await ctx.db.delete(series).where(eq(series.id, seriesId));
+              }
+              // update that series id in the current post
+              await ctx.db
+              .update(post)
+              .set({
+                  seriesId: null
+              })
+              .where(eq(post.id, currentPost.id));
+            }
+            
+            if(seriesName){
+                // check if the current post is already linked to a series
+                if(currentPost?.seriesId){
+                    // check if the series title is same as the current series name
+                    // then we do nothing
+                    if(currentPost?.series?.title !== seriesName){
+                        // then the user has updated the series name in this particular edit
+                        // Check if there is another post with the same title, else delete the series
+                        // and create a new post with the new series name
+                        // and update that new series id in the post
+                        await unlinkSeries(currentPost.seriesId);
+                        await createNewSeries(seriesName);
+                    }
+                }
+                else{
+                    // the current post is not yet linked to a seriesId
+                    // so create a new series and put that Id in the post
+                    await createNewSeries(seriesName);
+                }
+            }
+            else{
+                // either the user has not added the series Name (We do nothing)
+                // or while editing the post, the user has removed the series name
+                if(currentPost.seriesId !== null){
+                    await unlinkSeries(currentPost.seriesId);
+                }
+            } 
+        })
+})

--- a/server/api/router/series.ts
+++ b/server/api/router/series.ts
@@ -8,7 +8,11 @@ export const seriesRouter = createTRPCRouter({
         .input(UpdateSeriesSchema)
         .mutation(async ({input, ctx}) => {
             const {postId, seriesName} = input;
-            console.group("series Name: ", seriesName);
+
+            if (seriesName && seriesName.trim() === "") {
+                throw new TRPCError({ code: 'BAD_REQUEST', message: 'Series name cannot be empty' });
+            }
+
             const currentPost = await ctx.db.query.post.findFirst({
                 columns: {
                   id: true,
@@ -25,6 +29,10 @@ export const seriesRouter = createTRPCRouter({
                 },
                 where: (post, { eq }) => eq(post.id, postId),
               });
+
+            if (!currentPost) {
+                throw new TRPCError({ code: 'NOT_FOUND' });
+            }
             if (currentPost?.userId !== ctx.session.user.id) {
                 throw new TRPCError({
                   code: "FORBIDDEN",
@@ -33,54 +41,61 @@ export const seriesRouter = createTRPCRouter({
             const createNewSeries = async (seriesTitle: string) => {
               // check if a series with that name already exists
               // or else create a new one
-              let seriesId : number;
-              const currSeries = await ctx.db.query.series.findFirst({
-                columns: {
-                  id: true
-                },
-                where: (series, { eq }) => eq(series.title, seriesTitle),
-              })
-              if(!currSeries){
-                const [newSeries] = await ctx.db.insert(series).values({
-                  title: seriesTitle, 
-                  userId: ctx.session.user.id,
-                  updatedAt: new Date()  
-                }).returning();
-                
-                seriesId = newSeries.id;
-              }
-              else{
-                seriesId = currSeries.id;
-              }
-                // update that series id in the current post
-                await ctx.db
-                .update(post)
-                .set({
-                    seriesId: seriesId
+              return await ctx.db.transaction(async (tx) => {
+                let seriesId : number;
+                const currSeries = await tx.query.series.findFirst({
+                    columns: {
+                    id: true
+                    },
+                    where: (series, { eq }) => eq(series.title, seriesTitle),
                 })
-                .where(eq(post.id, currentPost.id));
+                
+                if(!currSeries){
+                    const [newSeries] = await tx.insert(series).values({
+                    title: seriesTitle, 
+                    userId: ctx.session.user.id,
+                    updatedAt: new Date()  
+                    }).returning();
+                    
+                    seriesId = newSeries.id;
+                }
+                else{
+                    seriesId = currSeries.id;
+                }
+                    // update that series id in the current post
+                    await tx
+                    .update(post)
+                    .set({
+                        seriesId: seriesId
+                    })
+                    .where(eq(post.id, currentPost.id));
+                })
+
             }
+
             const unlinkSeries = async (seriesId: number) => {
               // Check if the user has added a another post with the same series id previously
-              const anotherPostInThisSeries = await ctx.db.query.post.findFirst({
-                where: (post, { eq, and, ne }) => 
-                    and (
-                      ne(post.id, currentPost.id),
-                      eq(post.seriesId, currentPost.seriesId!)
-                    )
-              })
-              // if another post with the same seriesId is present, then do nothing
-              // else remove the series from the series table
-              if(!anotherPostInThisSeries){
-                  await ctx.db.delete(series).where(eq(series.id, seriesId));
-              }
-              // update that series id in the current post
-              await ctx.db
-              .update(post)
-              .set({
-                  seriesId: null
-              })
-              .where(eq(post.id, currentPost.id));
+                return await ctx.db.transaction(async (tx) =>{
+                    const anotherPostInThisSeries = await tx.query.post.findFirst({
+                        where: (post, { eq, and, ne }) => 
+                            and (
+                            ne(post.id, currentPost.id),
+                            eq(post.seriesId, currentPost.seriesId!)
+                            )
+                    })
+                    // if another post with the same seriesId is present, then do nothing
+                    // else remove the series from the series table
+                    if(!anotherPostInThisSeries){
+                        await tx.delete(series).where(eq(series.id, seriesId));
+                    }
+                    // update that series id in the current post
+                    await tx
+                    .update(post)
+                    .set({
+                        seriesId: null
+                    })
+                    .where(eq(post.id, currentPost.id));
+                })
             }
             
             if(seriesName){

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -35,6 +35,24 @@ export const sessionRelations = relations(session, ({ one }) => ({
   }),
 }));
 
+export const series = pgTable("Series", {
+  id: serial("id").primaryKey(),
+  title: text("title").notNull(),
+  description: text("description"),
+  userId: text("userId"),
+  createdAt: timestamp("createdAt", {
+    precision: 3,
+    mode: "string",
+    withTimezone: true,
+  })
+    .default(sql`CURRENT_TIMESTAMP`)
+    .notNull(),
+  updatedAt: timestamp("updatedAt", {
+    precision: 3,
+    withTimezone: true
+  }).notNull()
+})
+
 export const account = pgTable(
   "account",
   {
@@ -149,6 +167,7 @@ export const post = pgTable(
       .references(() => user.id, { onDelete: "cascade", onUpdate: "cascade" }),
     showComments: boolean("showComments").default(true).notNull(),
     likes: integer("likes").default(0).notNull(),
+    seriesId: integer("seriesId")
   },
   (table) => {
     return {
@@ -168,6 +187,7 @@ export const postRelations = relations(post, ({ one, many }) => ({
   notifications: many(notification),
   user: one(user, { fields: [post.userId], references: [user.id] }),
   tags: many(post_tag),
+  series: one(series,{ fields: [post.seriesId], references: [series.id] }),
 }));
 
 export const user = pgTable(


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

Fixes #1081 
<!-- for example `Fixes #1012` -->

## Pull Request details
- Added an extra input field in the more options section (While creating a new post) under the Canonical Url and Draft link
- Added a new table in the database called "series"
- Added a new field in the post table called seriesId referencing the id of the series table

### Cases considered
- **CREATE**
When the user creates a new record will be created in the series table

- **EDIT**
1) If the user adds a series name to a post which didn't have a series then a new record will be created
2) If the user changes the series name to a new series name (which is not present in the db), then a new record will be created in the series table. (The previous series will be removed from the series table, if no other post has that series name to maintain consistency).
3) If the user removes the series name then the seriesId in the post table will be set to null. (The previous series will be removed from the series table, if no other post has that series name to maintain consistency)

- **DELETE**
If the user deletes the post which had a series name then the series will be removed from the series table, if no other post has that series.

## Any Breaking changes
None

## Note to Reviewers
Please let me know,
- If there is any case missed
- any change in coding style required
- any error case not handled
- any other change required

## Associated Screenshots
UI
![image](https://github.com/user-attachments/assets/4413453d-c22a-47c7-9023-7d88d720de67)

Working video
![series codu](https://github.com/user-attachments/assets/f3cc72f8-9e35-4eb7-9e64-8a8d8bf80a59)


