### PR TITLE
feat: Ensure the article appears exactly as it will when published #1102

### DIFF
--- a/components/editor/editor/RenderPost.tsx
+++ b/components/editor/editor/RenderPost.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { TiptapExtensions } from "./extensions";
 import { EditorContent, useEditor } from "@tiptap/react";
+import SlashCommand from "./extensions/slash-command";
 
 interface RenderPostProps {
   json: string;
@@ -11,7 +12,7 @@ const RenderPost = ({ json }: RenderPostProps) => {
 
   const editor = useEditor({
     editable: false,
-    extensions: [...TiptapExtensions],
+    extensions: [...TiptapExtensions, SlashCommand],
     content,
   });
 

--- a/components/editor/editor/extensions/index.tsx
+++ b/components/editor/editor/extensions/index.tsx
@@ -138,7 +138,6 @@ export const TiptapExtensions = [
       return "type / to see a list of formatting features";
     },
   }),
-  SlashCommand,
   TextStyle,
   Link.configure({
     HTMLAttributes: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "@tiptap/extension-typography": "^2.8.0",
         "@tiptap/extension-underline": "^2.6.6",
         "@tiptap/extension-youtube": "^2.6.6",
+        "@tiptap/html": "^2.8.0",
         "@tiptap/pm": "^2.5.1",
         "@tiptap/react": "^2.6.6",
         "@tiptap/starter-kit": "^2.6.6",
@@ -8419,6 +8420,23 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/html": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/html/-/html-2.8.0.tgz",
+      "integrity": "sha512-eOmceeQmJoYk0T6TvmaoPhVLV3yseyb8O/MewoviP1lImcdrYNw/HOifYLG1Ni/g1TzeOvbVyzF1hTJTRzyXYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zeed-dom": "^0.15.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
       }
     },
     "node_modules/@tiptap/pm": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10608,7 +10608,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
       "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       },
@@ -19160,6 +19159,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zeed-dom": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/zeed-dom/-/zeed-dom-0.15.1.tgz",
+      "integrity": "sha512-dtZ0aQSFyZmoJS0m06/xBN1SazUBPL5HpzlAcs/KcRW0rzadYw12deQBjeMhGKMMeGEp7bA9vmikMLaO4exBcg==",
+      "license": "MIT",
+      "dependencies": {
+        "css-what": "^6.1.0",
+        "entities": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=14.13.1"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/holtwick"
+      }
+    },
+    "node_modules/zeed-dom/node_modules/entities": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-5.0.0.tgz",
+      "integrity": "sha512-BeJFvFRJddxobhvEdm5GqHzRV/X+ACeuw0/BuuxsCh1EUZcAIz8+kYmBp/LrQuloy6K1f3a0M7+IhmZ7QnkISA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@tiptap/extension-typography": "^2.8.0",
     "@tiptap/extension-underline": "^2.6.6",
     "@tiptap/extension-youtube": "^2.6.6",
+    "@tiptap/html": "^2.8.0",
     "@tiptap/pm": "^2.5.1",
     "@tiptap/react": "^2.6.6",
     "@tiptap/starter-kit": "^2.6.6",


### PR DESCRIPTION
Fixes #1102 

## Pull Request details

- Implement exact rendering of articles on the article page, ensuring they appear as the user typed.
- This PR supports backward compatibility with previous articles stored in markdown format, while properly rendering new articles stored in the JSON format.

## Any Breaking changes
- If the "Excerpt" input is left blank in the alpha editor, the default preview will display JSON output. This happens because the article content is stored in JSON format, and without an excerpt, the backend defaults to using the article content for the preview.

## Associated Videos

Preview of new JSON content: 

https://github.com/user-attachments/assets/f9d02c78-08ce-4ff5-b793-68ae69181c73

Preview of old Markdown content:

https://github.com/user-attachments/assets/ae932763-dc4e-41ed-becd-d9570cfed1c4

## Screenshot of issue 
![image](https://github.com/user-attachments/assets/f0711bf8-5f1f-41d6-ac7e-6a80c4d4edb2)
