### PR TITLE
fix: bookmark icon should be visible for unauthenticated user in article test suite

### DIFF
--- a/e2e/articles.spec.ts
+++ b/e2e/articles.spec.ts
@@ -16,7 +16,7 @@ test.describe("Unauthenticated Articles Page", () => {
     );
   });
 
-  test("Should not show bookmark article icon", async ({ page }) => {
+  test("Should show bookmark article icon", async ({ page }) => {
     await page.goto("http://localhost:3000/articles");
 
     await expect(
@@ -25,7 +25,7 @@ test.describe("Unauthenticated Articles Page", () => {
 
     await expect(
       page.locator("article").first().getByLabel("Bookmark this post"),
-    ).toBeHidden();
+    ).toBeVisible();
   });
   test("Should load more articles when scrolling to the end of the page", async ({
     page,
@@ -164,6 +164,12 @@ test.describe("Authenticated Articles Page", () => {
 
     await expect(page.getByRole("button", { name: "Next" })).toBeVisible();
     await page.getByRole("button", { name: "Next" }).click();
+
+    await page.route("**/*", async (route) => {
+      await new Promise((f) => setTimeout(f, 500));
+      await route.continue();
+    });
+
     await expect(
       page.getByRole("button", { name: "Publish now" }),
     ).toBeVisible();

--- a/e2e/articles.spec.ts
+++ b/e2e/articles.spec.ts
@@ -165,11 +165,6 @@ test.describe("Authenticated Articles Page", () => {
     await expect(page.getByRole("button", { name: "Next" })).toBeVisible();
     await page.getByRole("button", { name: "Next" }).click();
 
-    await page.route("**/*", async (route) => {
-      await new Promise((f) => setTimeout(f, 500));
-      await route.continue();
-    });
-
     await expect(
       page.getByRole("button", { name: "Publish now" }),
     ).toBeVisible();


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

Fixes a flaky bookmark E2E test. No issue for this one

## Pull Request details

- This was just faulty logic on my part. I thought the bookmark icons were not displayed to unauthenticated users but they actually are
- Reason this was passing but flaky was because the articles were not loaded in time before the test assertions. This resulted in them being 'hidden'

## Any Breaking changes

- None

## Associated Screenshots

<img width="1724" alt="image" src="https://github.com/user-attachments/assets/deedba2f-f1e4-4f92-b588-f77a506b811f">
Shows bookmark icon for unauthenticated user
