### PR TITLE
feat: adding e2e test for article commenting

### DIFF
--- a/e2e/articles.spec.ts
+++ b/e2e/articles.spec.ts
@@ -185,4 +185,28 @@ test.describe("Authenticated Articles Page", () => {
     await expect(page.getByLabel("like-trigger")).toBeVisible();
     await expect(page.getByLabel("bookmark-trigger")).toBeVisible();
   });
+
+  test("Should post a comment on an article", async ({ page, isMobile }) => {
+    await page.goto("http://localhost:3000");
+    // Waits for articles to be loaded
+    await expect(page.getByText("Read Full Article").first()).toBeVisible();
+    page.getByText("Read Full Article").first().click();
+    await page.waitForURL(/^http:\/\/localhost:3000\/articles\/.*$/);
+
+    await expect(page.getByPlaceholder("What do you think?")).toBeVisible();
+    await page
+      .getByPlaceholder("What do you think?")
+      .fill("This is a great article. Thanks for posting it!");
+    await page.getByRole("button", { name: "Submit" }).click();
+
+    await expect(
+      page.getByRole("link", { name: "E2E Test User", exact: true }),
+    ).toBeVisible();
+
+    await expect(
+      page.locator("div").filter({
+        hasText: /^This is a great article\. Thanks for posting it!$/,
+      }),
+    ).toBeVisible();
+  });
 });

--- a/e2e/articles.spec.ts
+++ b/e2e/articles.spec.ts
@@ -65,7 +65,7 @@ test.describe("Unauthenticated Articles Page", () => {
     await page.goto("http://localhost:3000");
     // Waits for articles to be loaded
     await expect(page.getByText("Read Full Article").first()).toBeVisible();
-    page.getByText("Read Full Article").first().click();
+    await page.getByText("Read Full Article").first().click();
     await page.waitForURL(/^http:\/\/localhost:3000\/articles\/.*$/);
 
     await expect(page.getByPlaceholder("What do you think?")).toBeHidden();
@@ -205,15 +205,12 @@ test.describe("Authenticated Articles Page", () => {
     await expect(page.getByLabel("bookmark-trigger")).toBeVisible();
   });
 
-  test("Should post a comment on an article", async ({
-    page,
-    browserName,
-  }, workerInfo) => {
+  test("Should post a comment on an article", async ({ page }, workerInfo) => {
     const commentContent = `This is a great read. Thanks for posting! Sent from ${workerInfo.project.name} + ${randomUUID()}`;
     await page.goto("http://localhost:3000");
     // Waits for articles to be loaded
     await expect(page.getByText("Read Full Article").first()).toBeVisible();
-    page.getByText("Read Full Article").first().click();
+    await page.getByText("Read Full Article").first().click();
     await page.waitForURL(/^http:\/\/localhost:3000\/articles\/.*$/);
 
     await expect(page.getByPlaceholder("What do you think?")).toBeVisible();

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,9 +37,8 @@ export default defineConfig({
   projects: [
     { name: "setup", testMatch: /auth.setup\.ts/ },
     {
-      name: "chromium",
+      name: "Desktop Chrome",
       use: {
-        ...devices["Desktop Chrome"],
         storageState: "playwright/.auth/browser.json",
       },
       dependencies: ["setup"],
@@ -47,7 +46,7 @@ export default defineConfig({
 
     // Example other browsers
     {
-      name: "firefox",
+      name: "Desktop Firefox",
       use: {
         ...devices["Desktop Firefox"],
         storageState: "playwright/.auth/browser.json",


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

Improves E2E testing for the project by adding tests around a user commenting on an article

## Pull Request details

- Checks authenticated user can post a comment
- Checks that an unauthenticated user cannot post a comment

## Any Breaking changes

- None

## Associated Screenshots

![image](https://github.com/user-attachments/assets/01af819a-f7b2-4e53-b610-510556c50115)
Tests passing

![image](https://github.com/user-attachments/assets/adc1c467-a32c-4f99-9497-047891cf77ed)
Example comment generated by E2E test. The uuid needs to be added as if multiple a user runs the test suite multiple times we want to always ensure we are finding the comment created for that specific test run
