### PR TITLE
Fix fancy link - issue #1160

### DIFF
--- a/app/(app)/create/[[...paramsArr]]/_client.tsx
+++ b/app/(app)/create/[[...paramsArr]]/_client.tsx
@@ -796,7 +796,7 @@ const Create = () => {
                       href="https://www.markdownguide.org/"
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="fancy-link"
+                      className="cursor-pointer bg-gradient-to-r from-orange-400 to-pink-600 bg-clip-text tracking-wide text-transparent hover:from-orange-300 hover:to-pink-500"
                     >
                       this
                     </a>{" "}
@@ -805,7 +805,7 @@ const Create = () => {
                       href="https://www.markdownguide.org/"
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="fancy-link"
+                      className="cursor-pointer bg-gradient-to-r from-orange-400 to-pink-600 bg-clip-text tracking-wide text-transparent hover:from-orange-300 hover:to-pink-500"
                     >
                       markdownguide
                     </a>

--- a/app/(app)/get-started/_client.tsx
+++ b/app/(app)/get-started/_client.tsx
@@ -39,7 +39,10 @@ const GetStarted: NextPage = () => {
           </h2>
           <p className="mt-2 text-center text-base text-neutral-500">
             Or{" "}
-            <Link className="cursor-pointer bg-gradient-to-r from-orange-400 to-pink-600 bg-clip-text tracking-wide text-transparent hover:from-orange-300 hover:to-pink-500 font-medium" href="/">
+            <Link
+              className="cursor-pointer bg-gradient-to-r from-orange-400 to-pink-600 bg-clip-text font-medium tracking-wide text-transparent hover:from-orange-300 hover:to-pink-500"
+              href="/"
+            >
               return home
             </Link>
           </p>

--- a/app/(app)/get-started/_client.tsx
+++ b/app/(app)/get-started/_client.tsx
@@ -39,7 +39,7 @@ const GetStarted: NextPage = () => {
           </h2>
           <p className="mt-2 text-center text-base text-neutral-500">
             Or{" "}
-            <Link className="fancy-link font-medium" href="/">
+            <Link className="cursor-pointer bg-gradient-to-r from-orange-400 to-pink-600 bg-clip-text tracking-wide text-transparent hover:from-orange-300 hover:to-pink-500 font-medium" href="/">
               return home
             </Link>
           </p>

--- a/components/ArticlePreview/ArticlePreview.tsx
+++ b/components/ArticlePreview/ArticlePreview.tsx
@@ -145,7 +145,7 @@ const ArticlePreview: NextPage<Props> = ({
       <div className="flex w-full content-center justify-between">
         <div className="flex w-full items-center justify-between">
           <Link
-            className="fancy-link semibold text-lg"
+            className="cursor-pointer bg-gradient-to-r from-orange-400 to-pink-600 bg-clip-text tracking-wide text-transparent hover:from-orange-300 hover:to-pink-500 semibold text-lg"
             href={`/articles/${slug}`}
           >
             Read full article

--- a/components/ArticlePreview/ArticlePreview.tsx
+++ b/components/ArticlePreview/ArticlePreview.tsx
@@ -145,7 +145,7 @@ const ArticlePreview: NextPage<Props> = ({
       <div className="flex w-full content-center justify-between">
         <div className="flex w-full items-center justify-between">
           <Link
-            className="cursor-pointer bg-gradient-to-r from-orange-400 to-pink-600 bg-clip-text tracking-wide text-transparent hover:from-orange-300 hover:to-pink-500 semibold text-lg"
+            className="semibold cursor-pointer bg-gradient-to-r from-orange-400 to-pink-600 bg-clip-text text-lg tracking-wide text-transparent hover:from-orange-300 hover:to-pink-500"
             href={`/articles/${slug}`}
           >
             Read full article

--- a/components/Comments/CommentsArea.tsx
+++ b/components/Comments/CommentsArea.tsx
@@ -505,11 +505,11 @@ const CommentsArea = ({ postId, postOwnerId }: Props) => {
             <p className="mb-2">Hey! 👋</p>
             <p className="mb-2">Got something to say?</p>
             <p>
-              <button onClick={() => signIn()} className="fancy-link">
+              <button onClick={() => signIn()} className="cursor-pointer bg-gradient-to-r from-orange-400 to-pink-600 bg-clip-text tracking-wide text-transparent hover:from-orange-300 hover:to-pink-500">
                 Sign in
               </button>{" "}
               or{" "}
-              <button onClick={() => signIn()} className="fancy-link">
+              <button onClick={() => signIn()} className="cursor-pointer bg-gradient-to-r from-orange-400 to-pink-600 bg-clip-text tracking-wide text-transparent hover:from-orange-300 hover:to-pink-500">
                 sign up
               </button>{" "}
               to leave a comment.

--- a/components/Comments/CommentsArea.tsx
+++ b/components/Comments/CommentsArea.tsx
@@ -505,11 +505,17 @@ const CommentsArea = ({ postId, postOwnerId }: Props) => {
             <p className="mb-2">Hey! 👋</p>
             <p className="mb-2">Got something to say?</p>
             <p>
-              <button onClick={() => signIn()} className="cursor-pointer bg-gradient-to-r from-orange-400 to-pink-600 bg-clip-text tracking-wide text-transparent hover:from-orange-300 hover:to-pink-500">
+              <button
+                onClick={() => signIn()}
+                className="cursor-pointer bg-gradient-to-r from-orange-400 to-pink-600 bg-clip-text tracking-wide text-transparent hover:from-orange-300 hover:to-pink-500"
+              >
                 Sign in
               </button>{" "}
               or{" "}
-              <button onClick={() => signIn()} className="cursor-pointer bg-gradient-to-r from-orange-400 to-pink-600 bg-clip-text tracking-wide text-transparent hover:from-orange-300 hover:to-pink-500">
+              <button
+                onClick={() => signIn()}
+                className="cursor-pointer bg-gradient-to-r from-orange-400 to-pink-600 bg-clip-text tracking-wide text-transparent hover:from-orange-300 hover:to-pink-500"
+              >
                 sign up
               </button>{" "}
               to leave a comment.

--- a/components/EditorHints/EditorHints.tsx
+++ b/components/EditorHints/EditorHints.tsx
@@ -29,7 +29,7 @@ const EditorHints = () => {
                 href="https://www.markdownguide.org/"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="fancy-link"
+                className="cursor-pointer bg-gradient-to-r from-orange-400 to-pink-600 bg-clip-text tracking-wide text-transparent hover:from-orange-300 hover:to-pink-500"
               >
                 this
               </a>{" "}
@@ -38,7 +38,7 @@ const EditorHints = () => {
                 href="https://www.markdownguide.org/"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="fancy-link"
+                className="cursor-pointer bg-gradient-to-r from-orange-400 to-pink-600 bg-clip-text tracking-wide text-transparent hover:from-orange-300 hover:to-pink-500"
               >
                 markdownguide
               </a>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -81,14 +81,6 @@ body {
   @apply bg-white bg-gradient-to-r text-neutral-800 dark:bg-neutral-900 dark:text-white;
 }
 
-.fancy-link {
-  @apply cursor-pointer bg-gradient-to-r from-orange-400 to-pink-600 bg-clip-text tracking-wide text-transparent;
-}
-
-.fancy-link:hover {
-  @apply from-orange-300 to-pink-500;
-}
-
 .prose {
   @apply prose-neutral dark:prose-invert lg:prose-lg;
 


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

Fixes #1160 

## Pull Request details

- Removed the .fancy-link and .fancy-link:hover classes from globals.css as part of the effort to follow the component-based styling approach promoted by Tailwind CSS.
- Applied the styles directly to the components using .fancy-link, replacing them with the equivalent Tailwind classes:
cursor-pointer bg-gradient-to-r from-orange-400 to-pink-600 bg-clip-text tracking-wide text-transparent hover:from-orange-300 hover:to-pink-500
- Ensured that the hover effects and link styling remain consistent across all relevant components.

## Any Breaking changes

None

## Associated Screenshots

None
