### PR TITLE
Removed the likes from the article preview

### DIFF
--- a/components/ArticlePreview/ArticlePreview.tsx
+++ b/components/ArticlePreview/ArticlePreview.tsx
@@ -7,7 +7,6 @@ import { Temporal } from "@js-temporal/polyfill";
 import {
   BookmarkIcon,
   EllipsisHorizontalIcon,
-  HeartIcon,
 } from "@heroicons/react/20/solid";
 import {
   Menu,
@@ -56,16 +55,15 @@ const ArticlePreview: NextPage<Props> = ({
   menuOptions,
   showBookmark = true,
   bookmarkedInitialState = false,
-  likes,
 }) => {
   const { data: session } = useSession();
   const [bookmarked, setIsBookmarked] = useState(bookmarkedInitialState);
   const howManySavedToShow = 3;
-  const { data: bookmarksData, refetch } = api.post.myBookmarks.useQuery(
+
+  const { refetch } = api.post.myBookmarks.useQuery(
     { limit: howManySavedToShow },
     { enabled: !!session },
   );
-  const bookmarks = bookmarksData?.bookmarks;
   const dateTime = Temporal.Instant.from(new Date(date).toISOString());
   const readableDate = dateTime.toLocaleString(["en-IE"], {
     year: "numeric",
@@ -128,15 +126,6 @@ const ArticlePreview: NextPage<Props> = ({
                 <>
                   <span aria-hidden="true">&middot;</span>
                   <span>{readTime} min read</span>
-                  {likes && (
-                    <>
-                      <span aria-hidden="true">&middot;</span>
-                      <span data-likes={likes}>{likes}</span>
-                      <HeartIcon
-                        className={`relative top-[1px] h-3.5 w-3.5 fill-red-400`}
-                      />
-                    </>
-                  )}
                 </>
               )}
               <div className="flex items-center justify-start"></div>


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

Removed the likes from the article preview

## Pull Request details

- Removed the likes from the article preview
- There was an issue showing 0 when no likes were present:
![Showing likes with and without data](https://github.com/user-attachments/assets/201dad2e-b3a7-492c-85fc-9e108cec30d4)
- I don't like having public likes on the cards because I think it might stop people clicking through if it has no likes even if it's well written. 
- Remove unused bookmark data
