### PR TITLE
Fix: Moved Sonner inside ThemeProvider to adapt dark/light theme

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -81,11 +81,11 @@ export default async function RootLayout({
       <CSPostHogProvider>
         <body className="h-full">
           <PostHogPageView />
-          <Toaster />
           <A11yProvider>
             <ProgressBar />
             <AuthProvider>
               <ThemeProvider>
+                <Toaster />
                 <TRPCReactProvider headers={headers()}>
                   <PromptProvider>{children}</PromptProvider>
                 </TRPCReactProvider>


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

Fixes #1235

## Pull Request details

- **Issue**: Toaster component does not adapt to dark/light mode changes.
- **What has been changed**:
  - Moved the `<Toaster />` component inside the `<ThemeProvider>` to ensure it follows the active theme (dark or light mode).
  - This change ensures that the toast notifications reflect the current theme of the app.
- **Why**: The `<Toaster />` was placed outside the theme provider, causing it to not inherit the current theme when it changes.

## Any Breaking changes

- None

## Associated Screenshots

- None

## [Optional] What gif best describes this PR or how it makes you feel

- None