### PR TITLE
removing the redundant nanoId package version | Issue No - #1270

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "lowlight": "^3.1.0",
     "lucide-react": "^0.451.0",
     "nanoid": "^5.0.9",
-    "nanoid": "^5.0.7",
     "next": "^14.2.21",
     "next-auth": "^4.24.9",
     "next-safe-action": "^7.9.4",


### PR DESCRIPTION
# ✨ Codu Pull Request 💻

Fixes #(issue)
Fix for issue #1270

## Pull Request details

- INFO ABOUT YOUR PULL REQUEST GOES HERE (Please be as descriptive as possible) 🤜
removing the redundant nanoId package version

Existing code:
    "nanoid": "^5.0.9",
    "nanoid": "^5.0.7",

