### PR TITLE
Fix phantom notifications badge showing count but empty page

### DIFF
--- a/server/api/router/notification.ts
+++ b/server/api/router/notification.ts
@@ -5,7 +5,7 @@ import {
   DeleteNotificationSchema,
 } from "../../../schema/notification";
 import { notification } from "@/server/db/schema";
-import { count, desc, eq } from "drizzle-orm";
+import { and, count, desc, eq, inArray, isNotNull } from "drizzle-orm";
 
 export const notificationRouter = createTRPCRouter({
   delete: protectedProcedure
@@ -66,6 +66,9 @@ export const notificationRouter = createTRPCRouter({
         where: (notifications, { eq, and, lte }) =>
           and(
             eq(notifications.userId, userId),
+            inArray(notifications.type, [0, 1]),
+            isNotNull(notifications.postId),
+            isNotNull(notifications.notifierId),
             cursor ? lte(notifications.id, cursor) : undefined,
           ),
         limit: limit + 1,
@@ -88,7 +91,14 @@ export const notificationRouter = createTRPCRouter({
     const [notificationRes] = await ctx.db
       .select({ count: count() })
       .from(notification)
-      .where(eq(notification.userId, userId));
+      .where(
+        and(
+          eq(notification.userId, userId),
+          inArray(notification.type, [0, 1]),
+          isNotNull(notification.postId),
+          isNotNull(notification.notifierId),
+        ),
+      );
 
     return notificationRes.count;
   }),


### PR DESCRIPTION
## Summary
- Notification count badge showed unread notifications, but the notifications page rendered nothing
- Root cause: `getCount` counted all notifications, but the UI only renders type 0 (comment) and type 1 (reply) with non-null `post` and `notifier` — orphaned notifications from the schema migration were counted but invisible
- Added server-side filtering to both `getCount` and `get` queries to only include renderable notifications (type in [0,1], non-null postId and notifierId)

## Test plan
- [ ] Verify notification badge count matches visible notifications on the page
- [ ] Verify "Mark all as read" clears all notifications correctly
- [ ] Verify new comment/reply notifications still appear and can be dismissed

🤖 Generated with [Claude Code](https://claude.com/claude-code)