### PR TITLE
fix: /feed.xml relation crash + blue form-input focus ring

### DIFF
--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -4,7 +4,20 @@ import { type Logger } from "drizzle-orm/logger";
 import postgres from "postgres";
 
 import { env } from "@/config/env";
-import * as schema from "@/server/db/schema";
+import * as schemaExports from "@/server/db/schema";
+
+// The schema barrel re-exports four tables under camelCase aliases for app-code
+// ergonomics (`post_votes as postVotes`, etc.). Those alias keys point at the
+// SAME table object as their snake_case originals, so handing the whole module
+// namespace to drizzle puts two keys per table into its tableNamesMap. The
+// collision makes drizzle attach each join table's relations to the alias key
+// and leave the canonical key with none, silently breaking relational queries
+// like `with: { tags }` / `with: { votes }` ("not enough information to infer
+// relation posts.tags"). Strip the aliases so each table reaches drizzle once;
+// app code still imports them from the schema barrel unchanged.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const { postVotes, commentVotes, postTags, feedSources, ...schema } =
+  schemaExports;
 
 /**
  * Cache the database connection in development. This avoids creating a new connection on every HMR

--- a/server/db/relations.test.ts
+++ b/server/db/relations.test.ts
@@ -17,21 +17,28 @@ describe("posts relational config", () => {
     ({ db } = await import("@/server/db"));
   });
 
-  it("registers relations on the join tables (no alias collision)", () => {
+  it("registers relations on all four aliased join tables (no collision)", () => {
     const schema = db._.schema;
-    expect(Object.keys(schema.post_tags.relations)).toContain("post");
-    expect(Object.keys(schema.post_tags.relations)).toContain("tag");
+    // All four tables that have a camelCase alias re-export must keep their
+    // relations registered under the canonical snake_case key.
+    expect(Object.keys(schema.post_tags.relations)).toEqual(
+      expect.arrayContaining(["post", "tag"]),
+    );
     expect(Object.keys(schema.post_votes.relations)).toContain("post");
+    expect(Object.keys(schema.comment_votes.relations)).toContain("comment");
+    expect(Object.keys(schema.feed_sources.relations)).toContain("user");
   });
 
-  it("builds the nested relational query used by /feed.xml", () => {
+  it("builds relational queries that walk the previously-broken relations", () => {
     expect(() =>
       db.query.posts
         .findMany({
           columns: { title: true },
           with: {
-            author: { columns: { username: true } },
-            tags: { with: { tag: true } },
+            author: { columns: { username: true } }, // used by /feed.xml
+            tags: { with: { tag: true } }, // post_tags
+            votes: true, // post_votes
+            source: true, // feed_sources (one)
           },
           limit: 1,
         })

--- a/server/db/relations.test.ts
+++ b/server/db/relations.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeAll } from "vitest";
+
+// Regression guard for the tableNamesMap collision: the schema barrel re-exports
+// a few tables under camelCase aliases (postVotes/postTags/...), and feeding both
+// keys to drizzle dropped the join tables' relations — which broke `with: { tags }`
+// / `with: { votes }` on /feed.xml ("not enough information to infer relation
+// posts.tags"). server/db/index.ts strips the aliases before handing the schema
+// to drizzle; these tests fail if that regresses.
+describe("posts relational config", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let db: any;
+
+  beforeAll(async () => {
+    process.env.SKIP_ENV_VALIDATION = "1";
+    process.env.DATABASE_URL ??= "postgres://user:pass@localhost:5432/test";
+    // Dynamic import so the env stubs above land before the module reads them.
+    ({ db } = await import("@/server/db"));
+  });
+
+  it("registers relations on the join tables (no alias collision)", () => {
+    const schema = db._.schema;
+    expect(Object.keys(schema.post_tags.relations)).toContain("post");
+    expect(Object.keys(schema.post_tags.relations)).toContain("tag");
+    expect(Object.keys(schema.post_votes.relations)).toContain("post");
+  });
+
+  it("builds the nested relational query used by /feed.xml", () => {
+    expect(() =>
+      db.query.posts
+        .findMany({
+          columns: { title: true },
+          with: {
+            author: { columns: { username: true } },
+            tags: { with: { tag: true } },
+          },
+          limit: 1,
+        })
+        .toSQL(),
+    ).not.toThrow();
+  });
+});

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -165,8 +165,8 @@ body {
    every form control. Recolour both to the brand accent so input focus matches
    the mint focus language used everywhere else (links/buttons already get a mint
    :focus-visible ring). Unlayered, so it reliably overrides the plugin's
-   @layer base styles. The thin ring doubles as the keyboard focus indicator, so
-   a11y is preserved — only the colour changes. */
+   @layer base styles. The plugin's thin ring (shown on :focus, pointer and
+   keyboard) is kept as the focus indicator — only the colour changes. */
 [type="text"]:focus,
 [type="email"]:focus,
 [type="url"]:focus,
@@ -180,6 +180,7 @@ body {
 [type="time"]:focus,
 [type="week"]:focus,
 [multiple]:focus,
+input:not([type]):focus,
 textarea:focus,
 select:focus {
   --tw-ring-color: rgb(var(--color-accent));

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -161,6 +161,31 @@ body {
   outline-offset: 2px;
 }
 
+/* @tailwindcss/forms paints a hardcoded blue (#2563eb) focus ring + border on
+   every form control. Recolour both to the brand accent so input focus matches
+   the mint focus language used everywhere else (links/buttons already get a mint
+   :focus-visible ring). Unlayered, so it reliably overrides the plugin's
+   @layer base styles. The thin ring doubles as the keyboard focus indicator, so
+   a11y is preserved — only the colour changes. */
+[type="text"]:focus,
+[type="email"]:focus,
+[type="url"]:focus,
+[type="password"]:focus,
+[type="number"]:focus,
+[type="date"]:focus,
+[type="datetime-local"]:focus,
+[type="month"]:focus,
+[type="search"]:focus,
+[type="tel"]:focus,
+[type="time"]:focus,
+[type="week"]:focus,
+[multiple]:focus,
+textarea:focus,
+select:focus {
+  --tw-ring-color: rgb(var(--color-accent));
+  border-color: rgb(var(--color-accent));
+}
+
 /* ── Eyebrow / kicker: the signature mono "// label" device ── */
 .eyebrow {
   @apply font-mono text-xs uppercase tracking-label text-accent;


### PR DESCRIPTION
Two production fixes.

## 1. `/feed.xml` 500 — "There is not enough information to infer relation posts.tags"
Sentry: `GET /feed.xml` throwing on every request (13 events).

**Root cause:** the schema barrel re-exports four tables under camelCase aliases (`post_votes as postVotes`, `comment_votes as commentVotes`, `post_tags as postTags`, `feed_sources as feedSources`). `server/db/index.ts` passed the whole `import * as schema` namespace to drizzle, so **two keys pointed at the same table object**, colliding drizzle's `tableNamesMap`. Drizzle attached each join table's relations to the *alias* key and left the canonical key with **empty relations** — so any `many` relational walk (`with: { tags }`, `with: { votes }`) couldn't find the reverse relation and threw. `/feed.xml` uses `with: { tags: { with: { tag: true } } }`, so it 500'd. `bookmarks`/`comments` (no alias) worked, which is why it looked selective.

**Fix:** strip the four aliases from the schema object handed to drizzle so each table is registered once. App code still imports the aliases from the barrel unchanged. Added `server/db/relations.test.ts` that asserts the join-table relations register and the exact `/feed.xml` query builds.

Verified by reproducing the build error locally, then confirming it's gone after the fix (`post_tags`/`post_votes` relations now populate; the feed query `.toSQL()` no longer throws).

## 2. Blue focus ring on form inputs
`@tailwindcss/forms` paints a hardcoded blue (`#2563eb`) focus ring + border on every form control, so text inputs lit up blue while links/buttons already used the mint `:focus-visible` ring. Recoloured the plugin's ring + border to the `--color-accent` token for all form controls — keeps an accessible, thin, on-brand focus indicator instead of the off-palette blue.

Verified via Playwright: input focus ring went from `#2563eb` → `rgb(45 212 191)` (accent); links/buttons unchanged; the command-palette input's existing subtle-underline treatment is unaffected.

## Checks
ESLint clean · `tsc` 0 errors · `server/db/relations.test.ts` + `utils/url.test.ts` pass (9 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)