### PR TITLE
fix(s3): trim whitespace in bucket name + creds so uploads can't break on a stray space

### DIFF
--- a/server/common/getPresignedUrl.test.ts
+++ b/server/common/getPresignedUrl.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 
 // Regression guard: a trailing space in S3_BUCKET_NAME (or the keys) once made
 // every presigned PUT fail with 400 InvalidBucketName. These values must be
@@ -13,6 +13,12 @@ describe("getPresignedUrl whitespace hardening", () => {
     process.env.ACCESS_KEY = "AKIATESTKEY1234567890 ";
     process.env.SECRET_KEY = "secretsecretsecretsecretsecretsecret1234\n";
     ({ getPresignedUrl } = await import("@/server/common/getPresignedUrl"));
+  });
+
+  afterAll(() => {
+    delete process.env.ACCESS_KEY;
+    delete process.env.SECRET_KEY;
+    delete process.env.S3_BUCKET_NAME;
   });
 
   it("trims a trailing space in S3_BUCKET_NAME so the PUT targets the real bucket", async () => {

--- a/server/common/getPresignedUrl.test.ts
+++ b/server/common/getPresignedUrl.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeAll } from "vitest";
+
+// Regression guard: a trailing space in S3_BUCKET_NAME (or the keys) once made
+// every presigned PUT fail with 400 InvalidBucketName. These values must be
+// trimmed before they reach the bucket name / SigV4 credential.
+describe("getPresignedUrl whitespace hardening", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let getPresignedUrl: any;
+
+  beforeAll(async () => {
+    // Whitespace-padded credentials, set before import so the s3 client (built
+    // at module load) sees them.
+    process.env.ACCESS_KEY = "AKIATESTKEY1234567890 ";
+    process.env.SECRET_KEY = "secretsecretsecretsecretsecretsecret1234\n";
+    ({ getPresignedUrl } = await import("@/server/common/getPresignedUrl"));
+  });
+
+  it("trims a trailing space in S3_BUCKET_NAME so the PUT targets the real bucket", async () => {
+    process.env.S3_BUCKET_NAME = "codu.uploads "; // <- the prod footgun
+    const url = await getPresignedUrl("image/png", 123, {
+      kind: "uploads",
+      userId: "u1",
+    });
+    expect(url).toContain("/codu.uploads/");
+    expect(url).not.toContain("codu.uploads%20");
+    expect(url).not.toContain("codu.uploads ");
+  });
+
+  it("trims whitespace in the access key used to sign the URL", async () => {
+    process.env.S3_BUCKET_NAME = "codu.uploads";
+    const url = await getPresignedUrl("image/png", 123, {
+      kind: "uploads",
+      userId: "u1",
+    });
+    const cred = new URL(url).searchParams.get("X-Amz-Credential") ?? "";
+    expect(cred.startsWith("AKIATESTKEY1234567890/")).toBe(true);
+    expect(cred).not.toContain("%20");
+  });
+});

--- a/server/common/getPresignedUrl.ts
+++ b/server/common/getPresignedUrl.ts
@@ -50,7 +50,6 @@ export const getPresignedUrl = async (
     ContentLength: fileSize,
   });
 
-  // @FIX TS ERROR
   const putUrl = await getSignedUrl(s3Client, putCommand, {
     expiresIn: 3600,
   });

--- a/server/common/getPresignedUrl.ts
+++ b/server/common/getPresignedUrl.ts
@@ -42,7 +42,9 @@ export const getPresignedUrl = async (
   const Key = getKey(config, extension);
 
   const putCommand = new PutObjectCommand({
-    Bucket: process.env.S3_BUCKET_NAME,
+    // Trim: a stray space in S3_BUCKET_NAME (invisible in host UIs) makes S3
+    // reject every PUT with 400 InvalidBucketName.
+    Bucket: process.env.S3_BUCKET_NAME?.trim(),
     Key,
     ContentType: `image/${fileType}`,
     ContentLength: fileSize,

--- a/utils/s3helpers.ts
+++ b/utils/s3helpers.ts
@@ -1,14 +1,17 @@
 import { S3Client } from "@aws-sdk/client-s3";
 
-const hasAccessKeys = process.env.ACCESS_KEY && process.env.SECRET_KEY;
+// Trim: stray whitespace in the key env vars otherwise breaks SigV4 signing.
+const accessKeyId = process.env.ACCESS_KEY?.trim();
+const secretAccessKey = process.env.SECRET_KEY?.trim();
+const hasAccessKeys = accessKeyId && secretAccessKey;
 
 export const s3Client = new S3Client({
   region: "eu-west-1",
   ...(hasAccessKeys
     ? {
         credentials: {
-          accessKeyId: process.env.ACCESS_KEY || "",
-          secretAccessKey: process.env.SECRET_KEY || "",
+          accessKeyId,
+          secretAccessKey,
         },
       }
     : {}),


### PR DESCRIPTION
## Problem
Uploads were **totally broken on production**. Root cause: a trailing space in the prod `S3_BUCKET_NAME` env var. Every presigned PUT targeted the invalid bucket name `"codu.uploads "`, so S3 returned **`400 InvalidBucketName`**.

The space is invisible in the Vercel UI, and `S3_BUCKET_NAME` / `ACCESS_KEY` / `SECRET_KEY` aren't in `config/env.js` validation — so the bad value failed silently at runtime instead of at boot. The bucket, CORS, public-read policy and IAM creds were all verified healthy; only the env value was bad.

## Fix
Trim these values at the point of use so stray whitespace on **any** of them can't break uploads:
- `getPresignedUrl.ts` → `Bucket: process.env.S3_BUCKET_NAME?.trim()`
- `utils/s3helpers.ts` → trim `ACCESS_KEY` / `SECRET_KEY` before they reach the SigV4 credential

## Test
`server/common/getPresignedUrl.test.ts` — fails without the trim (URL came out as `.../codu.uploads%20/...` with `X-Amz-Credential=...%20`), passes with it. Full unit suite green.

## Note
This is defence-in-depth — the live fix is also to retype the prod env value with no whitespace and redeploy. Follow-up worth considering: add the three S3 vars to `config/env.js` so bad values fail at boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)