### PR TITLE
fix(uploads): detect upload success via response.ok so the editor stops failing every image

### DIFF
--- a/app/(admin)/admin/sources/_client.tsx
+++ b/app/(admin)/admin/sources/_client.tsx
@@ -242,8 +242,11 @@ const AdminSourcesPage = () => {
         },
         async onSuccess(signedUrl) {
           try {
-            const response = await uploadFile(signedUrl, file);
-            const { fileLocation } = response;
+            const { ok, fileLocation } = await uploadFile(signedUrl, file);
+            if (!ok) {
+              toast.error("Failed to upload logo, please try again.");
+              return;
+            }
             setEditingSource({
               ...editingSource,
               logoUrl: fileLocation,

--- a/app/(app)/jobs/create/_client.tsx
+++ b/app/(app)/jobs/create/_client.tsx
@@ -127,8 +127,8 @@ export default function Content() {
           );
         }
 
-        const { fileLocation } = await uploadFile(signedUrl, file);
-        if (!fileLocation) {
+        const { ok, fileLocation } = await uploadFile(signedUrl, file);
+        if (!ok || !fileLocation) {
           setUploadStatus("error");
           return toast.error(
             "Something went wrong uploading the logo, please retry.",

--- a/app/(app)/settings/_client.tsx
+++ b/app/(app)/settings/_client.tsx
@@ -201,8 +201,12 @@ const Settings = ({ profile }: { profile: User }) => {
       return;
     }
 
-    const response = await uploadFile(signedUrl, file);
-    const { fileLocation } = response;
+    const { ok, fileLocation } = await uploadFile(signedUrl, file);
+    if (!ok) {
+      setProfilePhoto({ status: "error", url: "" });
+      return;
+    }
+
     await updateUserPhotoUrl({
       url: fileLocation,
     });

--- a/utils/s3helpers.test.ts
+++ b/utils/s3helpers.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { uploadFile } from "./s3helpers";
+
+// Regression guard: spreading a Response (`{ ...response }`) dropped its
+// prototype getters, so `result.ok` came back `undefined` and the editor
+// reported failure on every upload — even on a 200.
+describe("uploadFile", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockPutResponse(status: number, url: string) {
+    const response = new Response(null, { status });
+    // Response.url is read-only via the constructor; pin it for fileLocation.
+    Object.defineProperty(response, "url", { value: url });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response));
+  }
+
+  const file = new Blob(["x"], { type: "image/png" }) as unknown as File;
+
+  it("exposes ok=true on a successful PUT so callers can detect success", async () => {
+    mockPutResponse(
+      200,
+      "https://bucket.s3.amazonaws.com/uploads/u1/abc.png?sig=x",
+    );
+
+    const result = await uploadFile("https://signed-url", file);
+
+    expect(result.ok).toBe(true);
+    expect(result.fileLocation).toBe(
+      "https://bucket.s3.amazonaws.com/uploads/u1/abc.png",
+    );
+  });
+
+  it("exposes ok=false when S3 rejects the PUT", async () => {
+    mockPutResponse(
+      403,
+      "https://bucket.s3.amazonaws.com/uploads/u1/abc.png?sig=x",
+    );
+
+    const result = await uploadFile("https://signed-url", file);
+
+    expect(result.ok).toBe(false);
+  });
+});

--- a/utils/s3helpers.ts
+++ b/utils/s3helpers.ts
@@ -27,5 +27,7 @@ export const uploadFile = async (signedUrl: string, file: File) => {
   });
 
   const fileLocation = response.url.split("?")[0];
-  return { ...response, fileLocation };
+  // Pull fields off explicitly — spreading a Response drops its prototype
+  // getters (ok/status), leaving callers to read `undefined` for `ok`.
+  return { ok: response.ok, status: response.status, fileLocation };
 };


### PR DESCRIPTION
## What

Image uploads in the article editor showed **"Failed to upload image"** on every attempt, even though the file actually reached S3.

`uploadFile` returned `{ ...response, fileLocation }`. A fetch `Response` exposes `ok`, `status`, and `url` as **prototype getters**, not own-enumerable properties, so the spread copied none of them — callers read `undefined` for `ok`.

The editor's success check is `if (!uploadResult.ok) throw new Error("Failed to upload image")`, so `!undefined` threw on every upload. The presigned `PUT` returned `200` and the object landed in S3, but the UI reported failure and never inserted the image.

This was the remaining cause after the recent bucket-name trim (which fixed signing).

## How

- `uploadFile` now returns `{ ok, status, fileLocation }` explicitly instead of spreading the `Response`.
- Hardened the other three callers — profile photo, job logo, admin source logo — to check `ok`. Previously they trusted `fileLocation`, which is derived from `response.url` and is truthy even on a failed `PUT`, so a failed upload could silently be treated as success.
- Added a regression test for `uploadFile` covering the `ok`-on-success / `ok`-on-failure contract.

## Verification

- New test fails against the old spread (`result.ok` → `undefined`) and passes with the fix.
- Reproduced live: presigned URL targets the correct bucket, `PUT` returns `200`, object loads as an `<img>` — only the client-side `ok` check was wrong.
- `prettier`, `eslint`, and `tsc` clean on the changed files; unit tests pass.