### PR TITLE
fix(admin): let moderators preview a post before approving it

### DIFF
--- a/app/(admin)/admin/moderation/_client.tsx
+++ b/app/(admin)/admin/moderation/_client.tsx
@@ -40,6 +40,40 @@ const reasonLabels: Record<ReportReason, string> = {
 const chipBase =
   "rounded-full px-2 py-0.5 font-mono text-xs uppercase tracking-label";
 
+type PreviewablePost = {
+  type: string | null;
+  slug: string | null;
+  externalUrl: string | null;
+  authorUsername: string | null;
+};
+
+// Where to send a moderator to actually read the thing they're judging.
+// Discussions and questions live under /d/; a shared link IS its destination,
+// so it points off-site; everything else renders at /{username}/{slug}, where
+// the reader grants admins the same bypass the author has — so an in_review
+// post previews exactly as readers would eventually see it.
+function postPreviewHref(post: PreviewablePost): string | null {
+  if (post.type === "link") return post.externalUrl;
+  if (!post.slug) return null;
+  if (post.type === "discussion" || post.type === "question") {
+    return `/d/${post.slug}`;
+  }
+  if (!post.authorUsername) return null;
+  return `/${post.authorUsername}/${post.slug}`;
+}
+
+const PreviewLink = ({ post }: { post: PreviewablePost }) => {
+  const href = postPreviewHref(post);
+  if (!href) return null;
+
+  return (
+    <Link href={href} target="_blank" className="secondary-button">
+      <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+      Preview
+    </Link>
+  );
+};
+
 // datetime-local is in the moderator's LOCAL time, so shift the `min` boundary
 // by the tz offset before slicing to "YYYY-MM-DDTHH:mm".
 function localDateTimeMin(): string {
@@ -263,6 +297,11 @@ const ModerationQueue = () => {
                     @{post.authorUsername ?? "unknown"} ·{" "}
                     {getRelativeTime(post.createdAt!)}
                   </p>
+                  {post.excerpt && (
+                    <p className="mt-1 line-clamp-2 text-sm text-muted">
+                      {post.excerpt}
+                    </p>
+                  )}
                   {post.moderationNote && (
                     <p className="mt-1 text-sm text-muted">
                       <span className="font-medium text-fg">Reason:</span>{" "}
@@ -270,7 +309,8 @@ const ModerationQueue = () => {
                     </p>
                   )}
                 </div>
-                <div className="flex shrink-0 gap-2">
+                <div className="flex shrink-0 flex-wrap gap-2">
+                  <PreviewLink post={post} />
                   <button
                     className="primary-button"
                     disabled={isModerating}

--- a/app/(app)/[username]/[slug]/page.tsx
+++ b/app/(app)/[username]/[slug]/page.tsx
@@ -6,10 +6,11 @@ import { type Metadata } from "next";
 import { SITE_ORIGIN } from "@/config/site";
 import { db } from "@/server/db";
 import { posts, user, feed_sources, post_tags, tag } from "@/server/db/schema";
-import { eq, and, lte, inArray, or, sql } from "drizzle-orm";
+import { eq, and, lte, inArray, sql } from "drizzle-orm";
 import UserLinkDetail from "./_userLinkDetail";
 import PostReader from "@/components/ContentDetail/PostReader";
 import { parseUrlId, canonicalMismatch } from "@/server/lib/content-url";
+import { postVisibilityFilter } from "@/server/lib/postVisibility";
 import { serverApi } from "@/server/trpc/caller";
 import { JsonLd } from "@/components/JsonLd";
 import { getArticleSchema, getBreadcrumbSchema } from "@/lib/structured-data";
@@ -31,6 +32,7 @@ async function getUserPostUncached(
   username: string,
   postSlug: string,
   viewerId?: string | null,
+  viewerIsAdmin = false,
 ) {
   // Case-insensitive handle resolution (GitHub-style), matching the profile page.
   const userRecord = await db.query.user.findFirst({
@@ -40,22 +42,7 @@ async function getUserPostUncached(
 
   if (!userRecord) return null;
 
-  // Owner bypass: the author may view their own in_review/rejected post;
-  // everyone else only sees published posts whose publish time has passed.
-  const isAuthor = !!viewerId && viewerId === userRecord.id;
-
-  const visibilityFilter = isAuthor
-    ? or(
-        and(
-          eq(posts.status, "published"),
-          lte(posts.publishedAt, new Date().toISOString()),
-        ),
-        inArray(posts.status, ["in_review", "rejected"]),
-      )
-    : and(
-        eq(posts.status, "published"),
-        lte(posts.publishedAt, new Date().toISOString()),
-      );
+  const visibilityFilter = postVisibilityFilter({ viewerId, viewerIsAdmin });
 
   const postResults = await db
     .select({
@@ -376,7 +363,12 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   // Same viewerId as the page body so the cache()d resolver runs once per request.
   const session = await getServerAuthSession();
-  const userPost = await getUserPost(username, slug, session?.user?.id);
+  const userPost = await getUserPost(
+    username,
+    slug,
+    session?.user?.id,
+    session?.user?.role === "ADMIN",
+  );
   if (userPost) {
     // Discussions/questions canonicalize to /d/{slug}; redirect before metadata.
     if (isDiscussionKind(userPost.type)) {
@@ -533,7 +525,12 @@ const UnifiedPostPage = async (props: Props) => {
 
   const host = (await headers()).get("host") || "";
 
-  const userPost = await getUserPost(username, slug, session?.user?.id);
+  const userPost = await getUserPost(
+    username,
+    slug,
+    session?.user?.id,
+    session?.user?.role === "ADMIN",
+  );
 
   if (userPost) {
     // Discussions/questions live under /d/{slug} — redirect before rendering.

--- a/app/(app)/d/[slug]/page.tsx
+++ b/app/(app)/d/[slug]/page.tsx
@@ -7,11 +7,12 @@ import { ogPostImage } from "@/lib/og/url";
 import { getServerAuthSession } from "@/server/auth";
 import { db } from "@/server/db";
 import { posts, user, post_tags, tag, comments } from "@/server/db/schema";
-import { eq, and, lte, inArray, or, isNull, asc, type SQL } from "drizzle-orm";
+import { eq, and, inArray, or, isNull, asc, type SQL } from "drizzle-orm";
 import PostReader, {
   type ReaderPost,
 } from "@/components/ContentDetail/PostReader";
 import { parseUrlId, canonicalMismatch } from "@/server/lib/content-url";
+import { postVisibilityFilter } from "@/server/lib/postVisibility";
 import { JsonLd } from "@/components/JsonLd";
 import {
   getDiscussionForumPostingSchema,
@@ -26,6 +27,7 @@ type Props = { params: Promise<{ slug: string }> };
 async function getDiscussionPostUncached(
   slug: string,
   viewerId?: string | null,
+  viewerIsAdmin = false,
 ): Promise<ReaderPost | null> {
   const urlId = parseUrlId(slug);
   if (!urlId) return null;
@@ -37,13 +39,6 @@ async function getDiscussionPostUncached(
       ? eq(posts.urlId, urlId)
       : or(eq(posts.urlId, urlId), eq(posts.slug, slug))!;
 
-  const publicFilter = and(
-    eq(posts.status, "published"),
-    lte(posts.publishedAt, new Date().toISOString()),
-  );
-
-  // Owner bypass: the author may view their own in_review/rejected discussion;
-  // everyone else only sees published.
   const [row] = await db
     .select({
       id: posts.id,
@@ -73,15 +68,7 @@ async function getDiscussionPostUncached(
       and(
         idMatch,
         inArray(posts.type, ["discussion", "question"]),
-        viewerId
-          ? or(
-              publicFilter,
-              and(
-                eq(posts.authorId, viewerId),
-                inArray(posts.status, ["in_review", "rejected"]),
-              ),
-            )
-          : publicFilter,
+        postVisibilityFilter({ viewerId, viewerIsAdmin }),
       ),
     )
     .limit(1);
@@ -160,7 +147,11 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   const { slug } = await props.params;
   // Same viewerId as the page body so the cache()d resolver runs once per request.
   const session = await getServerAuthSession();
-  const post = await getDiscussionPost(slug, session?.user?.id);
+  const post = await getDiscussionPost(
+    slug,
+    session?.user?.id,
+    session?.user?.role === "ADMIN",
+  );
 
   if (!post) {
     return { title: "Discussion Not Found" };
@@ -210,7 +201,11 @@ const DiscussionPage = async (props: Props) => {
   const { slug } = await props.params;
   const session = await getServerAuthSession();
 
-  const post = await getDiscussionPost(slug, session?.user?.id);
+  const post = await getDiscussionPost(
+    slug,
+    session?.user?.id,
+    session?.user?.role === "ADMIN",
+  );
 
   if (!post) return notFound();
 

--- a/components/ContentDetail/PostReader.tsx
+++ b/components/ContentDetail/PostReader.tsx
@@ -120,8 +120,9 @@ const PostReader = async ({
   commentsDisabledLabel = "post",
   emitArticleSchema = true,
 }: PostReaderProps) => {
-  // Only reachable by the author (the resolver only returns non-published posts
-  // when viewerId matches the author's id).
+  // Only reachable by the author or an admin (the resolvers only return
+  // non-published posts when viewerId matches the author's id, or the viewer is
+  // an admin previewing from the moderation queue).
   const isAwaitingReview = post.status === "in_review";
   const isRejected = post.status === "rejected";
   const bodyContent = post.body ?? "";

--- a/server/api/router/admin.ts
+++ b/server/api/router/admin.ts
@@ -205,12 +205,19 @@ export const adminRouter = createTRPCRouter({
 
   // Auto-moderation queue: posts awaiting human review (status `in_review`).
   // `moderationNote` surfaces WHY a post was flagged (auto-mod reason, etc.).
+  // `excerpt` gives a moderator a first impression in the queue itself, while
+  // `type` and `externalUrl` decide where its Preview link points: /d/{slug}
+  // for discussions and questions, the linked page for shared links, and
+  // /{user}/{slug} for everything the site renders itself.
   listInReview: adminOnlyProcedure.query(async ({ ctx }) => {
     const rows = await ctx.db
       .select({
         id: posts.id,
         title: posts.title,
         slug: posts.slug,
+        type: posts.type,
+        excerpt: posts.excerpt,
+        externalUrl: posts.externalUrl,
         authorId: posts.authorId,
         authorUsername: user.username,
         authorName: user.name,

--- a/server/lib/postVisibility.test.ts
+++ b/server/lib/postVisibility.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { postVisibilityFilter } from "./postVisibility";
+
+const dialect = new PgDialect();
+
+// Statuses and ids are bound as parameters, so the interesting assertions are
+// about which values a viewer's filter binds, not the SQL text.
+const render = (viewer: Parameters<typeof postVisibilityFilter>[0]) => {
+  const { sql, params } = dialect.sqlToQuery(postVisibilityFilter(viewer));
+  return {
+    sql,
+    params,
+    scopesToAuthor: sql.includes('"author_id" = '),
+    allowsUnpublished:
+      params.includes("in_review") && params.includes("rejected"),
+  };
+};
+
+describe("postVisibilityFilter", () => {
+  it("shows an anonymous viewer only live posts", () => {
+    const filter = render({});
+
+    expect(filter.params).toContain("published");
+    expect(filter.sql).toContain('"published_at" <= ');
+    expect(filter.allowsUnpublished).toBe(false);
+  });
+
+  it("lets a signed-in viewer see unpublished posts only when they wrote them", () => {
+    const filter = render({ viewerId: "viewer-1" });
+
+    expect(filter.allowsUnpublished).toBe(true);
+    // The author predicate is what stops one member reading another's drafts.
+    expect(filter.scopesToAuthor).toBe(true);
+    expect(filter.params).toContain("viewer-1");
+  });
+
+  it("lets an admin see unpublished posts by any author", () => {
+    const filter = render({ viewerId: "admin-1", viewerIsAdmin: true });
+
+    expect(filter.allowsUnpublished).toBe(true);
+    expect(filter.scopesToAuthor).toBe(false);
+  });
+
+  it("does not grant the admin bypass on a plain signed-in session", () => {
+    const admin = render({ viewerId: "admin-1", viewerIsAdmin: true });
+    const member = render({ viewerId: "admin-1" });
+
+    expect(member.sql).not.toEqual(admin.sql);
+    expect(member.scopesToAuthor).toBe(true);
+  });
+
+  it("never exposes drafts, whoever is looking", () => {
+    for (const viewer of [
+      {},
+      { viewerId: "viewer-1" },
+      { viewerId: "admin-1", viewerIsAdmin: true },
+    ]) {
+      expect(render(viewer).params).not.toContain("draft");
+    }
+  });
+});

--- a/server/lib/postVisibility.ts
+++ b/server/lib/postVisibility.ts
@@ -1,0 +1,38 @@
+import { and, eq, inArray, lte, or, type SQL } from "drizzle-orm";
+import { posts } from "@/server/db/schema";
+
+/**
+ * Who is allowed to see a post that is not live yet.
+ *
+ * Every reader resolver applies the same rule, so it lives here rather than
+ * being restated per route: a post is visible when it is published and its
+ * publish time has passed, OR it is awaiting/failed review and the viewer is
+ * either its author or an admin. Admins get the author's view so the moderation
+ * queue can link straight to a full preview of a post it is asking them to
+ * approve.
+ *
+ * Callers that already pin an author in their WHERE (the /{username}/{slug}
+ * resolvers) still get the right answer: the extra authorId predicate here is
+ * simply redundant with theirs.
+ */
+export function postVisibilityFilter(viewer: {
+  viewerId?: string | null;
+  viewerIsAdmin?: boolean;
+}): SQL {
+  const live = and(
+    eq(posts.status, "published"),
+    lte(posts.publishedAt, new Date().toISOString()),
+  )!;
+
+  const notLiveYet = inArray(posts.status, ["in_review", "rejected"]);
+
+  if (viewer.viewerIsAdmin) {
+    return or(live, notLiveYet)!;
+  }
+
+  if (viewer.viewerId) {
+    return or(live, and(notLiveYet, eq(posts.authorId, viewer.viewerId)))!;
+  }
+
+  return live;
+}


### PR DESCRIPTION
## What

The **in review** queue at `/admin/moderation` listed a title, author and (now) an excerpt, but there was no way to actually read the post — so Approve/Decline was a judgement call with nothing to judge.

Each queued item now has a **Preview** link that opens where the post really renders:

| Post type | Preview goes to |
| --- | --- |
| `discussion`, `question` | `/d/{slug}` |
| `link` | the linked destination (that *is* the submission) |
| everything else | `/{username}/{slug}` |

For the last case the reader resolvers now grant admins the bypass authors already had for their own `in_review` / `rejected` posts, so a moderator sees the article exactly as readers eventually will — "Awaiting review" banner included — rather than a bespoke admin rendering that could drift from the real thing.

## Why the shared filter

That published-or-owner rule was about to exist in a third place, in a third shape. It moves to `server/lib/postVisibility.ts` and both reader resolvers call it.

The author predicate in there is the only thing stopping one member reading another's drafts, so it gets unit tests: anonymous sees live posts only, a signed-in member only bypasses for their own posts, an admin bypasses for any author, and no viewer ever sees `draft`.

## Verified locally

- Anonymous → 404 on an `in_review` post; signed-in non-author → 404; author → 200; admin → 200.
- Preview hrefs resolve correctly for all three post kinds, including a `link` post moved into review (which would otherwise 404, since the link resolver is published-only).
- `npm run lint`, `npm run prettier`, `npm run test:unit` (123 passing), `npm run build`.